### PR TITLE
Expand offline CRUD sync and enforce critical-only toast behavior

### DIFF
--- a/android/app/src/main/java/nvk/cotrip/data/repository/AiSuggestionsRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/AiSuggestionsRepositoryImpl.kt
@@ -4,9 +4,14 @@ import javax.inject.Inject
 import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.dto.AiSuggestionDto
 import nvk.cotrip.data.network.dto.AiSuggestionsRequestDto
+import nvk.cotrip.data.sync.SyncAiSuggestionSaveUpsertPayload
+import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.sync.SyncQueueRepository
+import java.io.IOException
 
 class AiSuggestionsRepositoryImpl @Inject constructor(
     private val api: CoTripApi,
+    private val syncQueueRepository: SyncQueueRepository,
 ) : AiSuggestionsRepository {
     override suspend fun generateSuggestions(
         tripId: String,
@@ -16,6 +21,14 @@ class AiSuggestionsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveSuggestionToIdeas(suggestionId: String) {
-        api.saveAiSuggestionToIdeas(suggestionId)
+        try {
+            api.saveAiSuggestionToIdeas(suggestionId)
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.AI_SUGGESTION_SAVE,
+                id = suggestionId,
+                payload = SyncAiSuggestionSaveUpsertPayload(suggestionId = suggestionId),
+            )
+        }
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
@@ -20,6 +20,7 @@ import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
 import java.io.IOException
+import java.time.OffsetDateTime
 import java.util.UUID
 import javax.inject.Inject
 
@@ -118,6 +119,7 @@ class ExpenseRepositoryImpl @Inject constructor(
             api.updateExpense(expenseId, request)
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.EXPENSE, expenseId, request)
+            applyExpenseUpdateLocally(expenseId = expenseId, request = request)
             return
         }
         safeLocalMutation("updateExpense.upsertExpense(expenseId=$expenseId)") {
@@ -135,7 +137,6 @@ class ExpenseRepositoryImpl @Inject constructor(
             api.deleteExpense(expenseId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.EXPENSE, expenseId)
-            return
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteExpense got 404 for expenseId=$expenseId, treating as already deleted")
@@ -159,6 +160,34 @@ class ExpenseRepositoryImpl @Inject constructor(
             safeLocalMutation("refreshExpenses.setExpenses(tripId=$tripId)") {
                 expensesCacheStore.setExpenses(tripId, expenses)
             }
+        }
+    }
+
+    private suspend fun applyExpenseUpdateLocally(
+        expenseId: String,
+        request: ExpenseUpdateRequest,
+    ) {
+        val local = runCatching { expensesCacheStore.findExpenseById(expenseId) }.getOrNull() ?: return
+        val updated = local.copy(
+            title = request.title ?: local.title,
+            amount = request.amount ?: local.amount,
+            status = request.status ?: local.status,
+            paidById = request.paidById ?: local.paidById,
+            date = request.date ?: local.date,
+            splitType = request.splitType ?: local.splitType,
+            note = request.note ?: local.note,
+            participants = request.participants?.map { participant ->
+                ExpenseParticipantDto(
+                    userId = participant.userId,
+                    shareAmount = participant.shareAmount,
+                    isIncluded = participant.isIncluded,
+                    isPaid = participant.isPaid,
+                    name = null,
+                )
+            } ?: local.participants,
+        )
+        safeLocalMutation("updateExpense.offlineUpsert(expenseId=$expenseId)") {
+            expensesCacheStore.upsertExpense(updated.tripId, updated)
         }
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
@@ -8,9 +8,11 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import nvk.cotrip.data.cache.IdeaCommentsCacheStore
 import nvk.cotrip.data.cache.IdeasCacheStore
+import nvk.cotrip.data.cache.ItineraryCacheStore
 import nvk.cotrip.data.cache.UserCacheStore
 import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.NetworkStateProvider
+import nvk.cotrip.data.network.dto.ActivityDto
 import nvk.cotrip.data.network.dto.CommentDto
 import nvk.cotrip.data.network.dto.ConvertIdeaRequest
 import nvk.cotrip.data.network.dto.CreateIdeaRequest
@@ -18,7 +20,9 @@ import nvk.cotrip.data.network.dto.IdeaDto
 import nvk.cotrip.data.network.dto.UpdateIdeaRequest
 import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.sync.SyncIdeaConvertCreatePayload
 import nvk.cotrip.data.sync.SyncIdeaCreatePayload
+import nvk.cotrip.data.sync.SyncIdeaStatusUpsertPayload
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
@@ -32,6 +36,7 @@ class IdeaRepositoryImpl @Inject constructor(
     private val syncQueueRepository: SyncQueueRepository,
     private val ideasCacheStore: IdeasCacheStore,
     private val commentsCacheStore: IdeaCommentsCacheStore,
+    private val itineraryCacheStore: ItineraryCacheStore,
     private val userCacheStore: UserCacheStore,
     private val networkStateProvider: NetworkStateProvider,
 ) : IdeaRepository {
@@ -114,6 +119,7 @@ class IdeaRepositoryImpl @Inject constructor(
             api.updateIdea(ideaId, request)
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.IDEA, ideaId, request)
+            applyIdeaUpdateLocally(ideaId, request)
             return
         }
         safeLocalMutation("updateIdea.upsertIdea(ideaId=$ideaId)") {
@@ -130,7 +136,6 @@ class IdeaRepositoryImpl @Inject constructor(
             api.deleteIdea(ideaId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.IDEA, ideaId)
-            return
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteIdea got 404 for ideaId=$ideaId, treating as already deleted")
@@ -150,11 +155,34 @@ class IdeaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun convertIdeaToActivity(ideaId: String, request: ConvertIdeaRequest) {
-        api.convertIdeaToActivity(ideaId, request).requireSuccess()
+        try {
+            api.convertIdeaToActivity(ideaId, request).requireSuccess()
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueCreate(
+                entity = SyncEntities.IDEA_CONVERT,
+                id = ideaId,
+                payload = SyncIdeaConvertCreatePayload(
+                    dayId = request.dayId,
+                    timeText = request.timeText,
+                    orderIndex = request.orderIndex,
+                ),
+            )
+            applyIdeaConvertLocally(ideaId = ideaId, request = request)
+            return
+        }
     }
 
     override suspend fun approveIdea(ideaId: String): IdeaDto {
-        val idea = api.approveIdea(ideaId)
+        val idea = try {
+            api.approveIdea(ideaId)
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.IDEA_STATUS,
+                id = ideaId,
+                payload = SyncIdeaStatusUpsertPayload(status = "approved"),
+            )
+            applyIdeaStatusLocally(ideaId = ideaId, status = "approved") ?: throw e
+        }
         safeLocalMutation("approveIdea.upsertIdea(ideaId=$ideaId)") {
             ideasCacheStore.upsertIdea(idea.tripId, idea)
         }
@@ -162,7 +190,16 @@ class IdeaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun rejectIdea(ideaId: String): IdeaDto {
-        val idea = api.rejectIdea(ideaId)
+        val idea = try {
+            api.rejectIdea(ideaId)
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.IDEA_STATUS,
+                id = ideaId,
+                payload = SyncIdeaStatusUpsertPayload(status = "rejected"),
+            )
+            applyIdeaStatusLocally(ideaId = ideaId, status = "rejected") ?: throw e
+        }
         safeLocalMutation("rejectIdea.upsertIdea(ideaId=$ideaId)") {
             ideasCacheStore.upsertIdea(idea.tripId, idea)
         }
@@ -195,6 +232,80 @@ class IdeaRepositoryImpl @Inject constructor(
             } while (cursor != null)
             safeLocalMutation("refreshComments.setComments(ideaId=$ideaId)") {
                 commentsCacheStore.setComments(ideaId, comments)
+            }
+        }
+    }
+
+    private suspend fun applyIdeaUpdateLocally(
+        ideaId: String,
+        request: UpdateIdeaRequest,
+    ) {
+        val local = runCatching { ideasCacheStore.findIdeaById(ideaId) }.getOrNull() ?: return
+        val updated = local.copy(
+            title = request.title ?: local.title,
+            city = request.city ?: local.city,
+            link = request.link ?: local.link,
+            costAmount = request.costAmount ?: local.costAmount,
+            costType = request.costType ?: local.costType,
+            notes = request.notes ?: local.notes,
+            updatedAt = OffsetDateTime.now().toString(),
+        )
+        safeLocalMutation("updateIdea.offlineUpsert(ideaId=$ideaId)") {
+            ideasCacheStore.upsertIdea(updated.tripId, updated)
+        }
+    }
+
+    private suspend fun applyIdeaStatusLocally(
+        ideaId: String,
+        status: String,
+    ): IdeaDto? {
+        val local = runCatching { ideasCacheStore.findIdeaById(ideaId) }.getOrNull() ?: return null
+        val updated = local.copy(
+            status = status,
+            updatedAt = OffsetDateTime.now().toString(),
+        )
+        safeLocalMutation("ideaStatus.offlineUpsert(ideaId=$ideaId,status=$status)") {
+            ideasCacheStore.upsertIdea(updated.tripId, updated)
+        }
+        return updated
+    }
+
+    private suspend fun applyIdeaConvertLocally(
+        ideaId: String,
+        request: ConvertIdeaRequest,
+    ) {
+        val sourceIdea = runCatching { ideasCacheStore.findIdeaById(ideaId) }.getOrNull() ?: return
+        val itineraryByTrip = runCatching { itineraryCacheStore.getAll() }.getOrDefault(emptyMap())
+        val tripId = itineraryByTrip.entries.firstOrNull { (_, days) ->
+            days.any { it.id == request.dayId }
+        }?.key ?: return
+
+        safeLocalMutation("convertIdea.offlineCreateActivity(ideaId=$ideaId,dayId=${request.dayId})") {
+            itineraryCacheStore.updateItinerary(tripId) { days ->
+                days.map { day ->
+                    if (day.id != request.dayId) {
+                        day
+                    } else {
+                        val orderIndex = request.orderIndex
+                            ?: ((day.activities.maxOfOrNull { it.orderIndex } ?: -1) + 1)
+                        val converted = ActivityDto(
+                            id = UUID.randomUUID().toString(),
+                            dayId = day.id,
+                            sourceIdeaId = sourceIdea.id,
+                            title = sourceIdea.title,
+                            timeText = request.timeText,
+                            locationName = sourceIdea.city,
+                            link = sourceIdea.link,
+                            costAmount = sourceIdea.costAmount,
+                            costType = sourceIdea.costType,
+                            notes = sourceIdea.notes,
+                            orderIndex = orderIndex,
+                        )
+                        day.copy(
+                            activities = (day.activities + converted).sortedBy { it.orderIndex }
+                        )
+                    }
+                }
             }
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
@@ -20,7 +20,9 @@ import nvk.cotrip.data.network.dto.UpdateActivityRequest
 import nvk.cotrip.data.network.dto.UpdateDayRequest
 import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncActivityCreatePayload
+import nvk.cotrip.data.sync.SyncActivityReorderUpsertPayload
 import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.sync.SyncItineraryTrimUpsertPayload
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
@@ -82,26 +84,8 @@ class ItineraryRepositoryImpl @Inject constructor(
             api.updateDay(dayId, request).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.DAY, dayId, request)
-            return
         }
-
-        safeLocalMutation("updateDay.updateItinerary(dayId=$dayId)") {
-            val tripId = findTripIdForDay(dayId) ?: return@safeLocalMutation
-            itineraryCacheStore.updateItinerary(tripId) { days ->
-                days.map { day ->
-                    if (day.id == dayId) {
-                        day.copy(
-                            city = request.city,
-                            cityProviderId = request.cityProviderId,
-                            cityLat = request.cityLat,
-                            cityLon = request.cityLon,
-                        )
-                    } else {
-                        day
-                    }
-                }
-            }
-        }
+        applyDayUpdateLocally(dayId = dayId, request = request)
     }
 
     override suspend fun createActivity(dayId: String, request: CreateActivityRequest): ActivityDto {
@@ -159,6 +143,7 @@ class ItineraryRepositoryImpl @Inject constructor(
             api.updateActivity(activityId, request)
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.ACTIVITY, activityId, request)
+            applyActivityUpdateLocally(activityId = activityId, request = request)
             return
         }
         safeLocalMutation("updateActivity.updateItinerary(activityId=$activityId)") {
@@ -183,6 +168,7 @@ class ItineraryRepositoryImpl @Inject constructor(
             api.moveActivity(activityId, request)
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.ACTIVITY, activityId, request)
+            applyActivityMoveLocally(activityId = activityId, request = request)
             return
         }
         safeLocalMutation("moveActivity.updateItinerary(activityId=$activityId)") {
@@ -208,7 +194,6 @@ class ItineraryRepositoryImpl @Inject constructor(
             api.deleteActivity(activityId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.ACTIVITY, activityId)
-            return
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteActivity got 404 for activityId=$activityId, treating as already deleted")
@@ -229,7 +214,18 @@ class ItineraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun reorderActivities(dayId: String, orderedIds: List<String>) {
-        api.reorderActivities(dayId, ReorderActivitiesRequest(orderedIds)).requireSuccess()
+        try {
+            api.reorderActivities(dayId, ReorderActivitiesRequest(orderedIds)).requireSuccess()
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.ACTIVITY_REORDER,
+                id = dayId,
+                payload = SyncActivityReorderUpsertPayload(
+                    dayId = dayId,
+                    orderedIds = orderedIds,
+                ),
+            )
+        }
         safeLocalMutation("reorderActivities.updateItinerary(dayId=$dayId)") {
             val tripId = findTripIdForDay(dayId) ?: return@safeLocalMutation
             itineraryCacheStore.updateItinerary(tripId) { days ->
@@ -244,8 +240,21 @@ class ItineraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun trimOutOfRange(tripId: String, request: TrimOutOfRangeRequest) {
-        api.trimOutOfRangeDays(tripId, request).requireSuccess()
-        refreshItinerary(tripId).getOrThrow()
+        try {
+            api.trimOutOfRangeDays(tripId, request).requireSuccess()
+            refreshItinerary(tripId).getOrThrow()
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.ITINERARY_TRIM,
+                id = tripId,
+                payload = SyncItineraryTrimUpsertPayload(
+                    tripId = tripId,
+                    action = request.action,
+                    dayIds = request.dayIds,
+                ),
+            )
+            applyTrimOutOfRangeLocally(tripId = tripId, request = request)
+        }
     }
 
     private suspend fun findTripIdForDay(dayId: String): String? {
@@ -285,5 +294,136 @@ class ItineraryRepositoryImpl @Inject constructor(
         val day = itinerary.firstOrNull { it.id == dayId } ?: return 0
         val maxOrder = day.activities.maxOfOrNull { it.orderIndex } ?: -1
         return maxOrder + 1
+    }
+
+    private suspend fun applyDayUpdateLocally(
+        dayId: String,
+        request: UpdateDayRequest,
+    ) {
+        safeLocalMutation("updateDay.updateItinerary(dayId=$dayId)") {
+            val tripId = findTripIdForDay(dayId) ?: return@safeLocalMutation
+            itineraryCacheStore.updateItinerary(tripId) { days ->
+                days.map { day ->
+                    if (day.id == dayId) {
+                        day.copy(
+                            city = request.city,
+                            cityProviderId = request.cityProviderId,
+                            cityLat = request.cityLat,
+                            cityLon = request.cityLon,
+                        )
+                    } else {
+                        day
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun applyActivityUpdateLocally(
+        activityId: String,
+        request: UpdateActivityRequest,
+    ) {
+        val lookup = findTripAndDayForActivity(activityId) ?: return
+        safeLocalMutation("updateActivity.offlineUpdate(activityId=$activityId)") {
+            itineraryCacheStore.updateItinerary(lookup.first) { days ->
+                days.map { day ->
+                    if (day.id != lookup.second) {
+                        day
+                    } else {
+                        day.copy(
+                            activities = day.activities.map { activity ->
+                                if (activity.id == activityId) {
+                                    activity.copy(
+                                        title = request.title ?: activity.title,
+                                        timeText = request.timeText ?: activity.timeText,
+                                        locationName = request.locationName ?: activity.locationName,
+                                        link = request.link ?: activity.link,
+                                        costAmount = request.costAmount ?: activity.costAmount,
+                                        costType = request.costType ?: activity.costType,
+                                        notes = request.notes ?: activity.notes,
+                                    )
+                                } else {
+                                    activity
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun applyActivityMoveLocally(
+        activityId: String,
+        request: MoveActivityRequest,
+    ) {
+        val source = findTripAndDayForActivity(activityId) ?: return
+        safeLocalMutation("moveActivity.offlineMove(activityId=$activityId)") {
+            itineraryCacheStore.updateItinerary(source.first) { days ->
+                var movedActivity: ActivityDto? = null
+                val without = days.map { day ->
+                    if (day.id == source.second) {
+                        val remaining = day.activities.filterNot { activity ->
+                            val shouldRemove = activity.id == activityId
+                            if (shouldRemove) {
+                                movedActivity = activity
+                            }
+                            shouldRemove
+                        }
+                        day.copy(activities = remaining)
+                    } else {
+                        day
+                    }
+                }
+                val candidate = movedActivity ?: return@updateItinerary without
+                without.map { day ->
+                    if (day.id != request.dayId) {
+                        day
+                    } else {
+                        val targetOrder = request.orderIndex
+                            ?: ((day.activities.maxOfOrNull { it.orderIndex } ?: -1) + 1)
+                        val moved = candidate.copy(dayId = request.dayId, orderIndex = targetOrder)
+                        day.copy(activities = (day.activities + moved).sortedBy { it.orderIndex })
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun applyTrimOutOfRangeLocally(
+        tripId: String,
+        request: TrimOutOfRangeRequest,
+    ) {
+        safeLocalMutation("trimOutOfRange.offlineApply(action=${request.action},tripId=$tripId)") {
+            itineraryCacheStore.updateItinerary(tripId) { days ->
+                when (request.action) {
+                    "keep" -> {
+                        days.map { day ->
+                            if (day.id in request.dayIds) {
+                                day.copy(isOutOfRange = true)
+                            } else {
+                                day
+                            }
+                        }
+                    }
+
+                    "remove" -> {
+                        days.filterNot { it.id in request.dayIds }
+                    }
+
+                    "extend_end" -> {
+                        days.map { day ->
+                            if (day.id in request.dayIds) {
+                                day.copy(isOutOfRange = false)
+                            } else {
+                                day
+                            }
+                        }
+                    }
+
+                    else -> days
+                }
+            }
+        }
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/NotificationRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/NotificationRepositoryImpl.kt
@@ -10,12 +10,17 @@ import nvk.cotrip.data.network.dto.NotificationSettingDto
 import nvk.cotrip.data.network.dto.NotificationSettingsUpdateRequest
 import nvk.cotrip.data.network.dto.PushTokenUpsertRequest
 import nvk.cotrip.data.network.requireSuccess
+import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.sync.SyncNotificationReadUpsertPayload
+import nvk.cotrip.data.sync.SyncNotificationSettingsUpsertPayload
+import nvk.cotrip.data.sync.SyncQueueRepository
 import java.io.IOException
 import javax.inject.Inject
 
 class NotificationRepositoryImpl @Inject constructor(
     private val api: CoTripApi,
     private val notificationsCacheStore: NotificationsCacheStore,
+    private val syncQueueRepository: SyncQueueRepository,
     private val networkStateProvider: NetworkStateProvider,
 ) : NotificationRepository {
 
@@ -36,7 +41,27 @@ class NotificationRepositoryImpl @Inject constructor(
 
     override suspend fun markRead(id: String) {
         if (networkStateProvider.isOnline()) {
-            api.markNotificationRead(id).requireSuccess()
+            try {
+                api.markNotificationRead(id).requireSuccess()
+            } catch (e: IOException) {
+                syncQueueRepository.enqueueUpsert(
+                    entity = SyncEntities.NOTIFICATION_READ,
+                    id = "single",
+                    payload = SyncNotificationReadUpsertPayload(
+                        mode = "single",
+                        notificationId = id,
+                    )
+                )
+            }
+        } else {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.NOTIFICATION_READ,
+                id = "single",
+                payload = SyncNotificationReadUpsertPayload(
+                    mode = "single",
+                    notificationId = id,
+                )
+            )
         }
         safeLocalMutation("markRead(notificationId=$id)") {
             notificationsCacheStore.markRead(id)
@@ -49,14 +74,33 @@ class NotificationRepositoryImpl @Inject constructor(
                 api.markNotificationsReadBulk(
                     NotificationReadBulkRequest(mode = "non_comment")
                 ).updated
+            }.onFailure { error ->
+                if (error is IOException) {
+                    syncQueueRepository.enqueueUpsert(
+                        entity = SyncEntities.NOTIFICATION_READ,
+                        id = "non_comment",
+                        payload = SyncNotificationReadUpsertPayload(mode = "non_comment"),
+                    )
+                }
             }
         } else {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.NOTIFICATION_READ,
+                id = "non_comment",
+                payload = SyncNotificationReadUpsertPayload(mode = "non_comment"),
+            )
             Result.success(0)
         }
         safeLocalMutation("markReadBulkNonComment") {
             notificationsCacheStore.markReadBulkNonComment()
         }
-        return remoteResult
+        return remoteResult.recoverCatching { error ->
+            if (error is IOException) {
+                0
+            } else {
+                throw error
+            }
+        }
     }
 
     override suspend fun markReadBulkIdeaComments(ideaId: String): Result<Int> {
@@ -68,14 +112,39 @@ class NotificationRepositoryImpl @Inject constructor(
                         ideaId = ideaId
                     )
                 ).updated
+            }.onFailure { error ->
+                if (error is IOException) {
+                    syncQueueRepository.enqueueUpsert(
+                        entity = SyncEntities.NOTIFICATION_READ,
+                        id = "idea_comments",
+                        payload = SyncNotificationReadUpsertPayload(
+                            mode = "idea_comments",
+                            ideaId = ideaId,
+                        ),
+                    )
+                }
             }
         } else {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.NOTIFICATION_READ,
+                id = "idea_comments",
+                payload = SyncNotificationReadUpsertPayload(
+                    mode = "idea_comments",
+                    ideaId = ideaId,
+                ),
+            )
             Result.success(0)
         }
         safeLocalMutation("markReadBulkIdeaComments(ideaId=$ideaId)") {
             notificationsCacheStore.markReadBulkIdeaComments(ideaId)
         }
-        return remoteResult
+        return remoteResult.recoverCatching { error ->
+            if (error is IOException) {
+                0
+            } else {
+                throw error
+            }
+        }
     }
 
     override suspend fun refreshSettings(): Result<Unit> {
@@ -92,7 +161,15 @@ class NotificationRepositoryImpl @Inject constructor(
 
     override suspend fun updateSettings(items: List<NotificationSettingDto>): Result<Unit> {
         if (!networkStateProvider.isOnline()) {
-            return Result.failure(IOException("Notification settings update requires network"))
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.NOTIFICATION_SETTINGS,
+                id = "me",
+                payload = SyncNotificationSettingsUpsertPayload(items = items),
+            )
+            safeLocalMutation("updateSettings.offlineSetSettings") {
+                notificationsCacheStore.setSettings(items)
+            }
+            return Result.success(Unit)
         }
         return runCatching {
             val response = api.updateNotificationSettings(
@@ -101,6 +178,17 @@ class NotificationRepositoryImpl @Inject constructor(
             safeLocalMutation("updateSettings.setSettings") {
                 notificationsCacheStore.setSettings(response.items)
             }
+        }.recoverCatching { error ->
+            if (error !is IOException) throw error
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.NOTIFICATION_SETTINGS,
+                id = "me",
+                payload = SyncNotificationSettingsUpsertPayload(items = items),
+            )
+            safeLocalMutation("updateSettings.offlineFallbackSetSettings") {
+                notificationsCacheStore.setSettings(items)
+            }
+            Unit
         }
     }
 

--- a/android/app/src/main/java/nvk/cotrip/data/repository/TripRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/TripRepositoryImpl.kt
@@ -20,6 +20,7 @@ import nvk.cotrip.data.network.dto.UpdateTripRequest
 import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncEntities
 import nvk.cotrip.data.sync.SyncQueueRepository
+import nvk.cotrip.data.sync.SyncTripMemberDeletePayload
 import nvk.cotrip.data.sync.SyncTripCreateDayPayload
 import nvk.cotrip.data.sync.SyncTripCreatePayload
 import nvk.cotrip.util.AppLogger
@@ -156,7 +157,7 @@ class TripRepositoryImpl @Inject constructor(
                     tripsCacheStore.upsertTrip(updatedLocal)
                 }
             }
-            Result.failure(e)
+            Result.success(Unit)
         }
     }
 
@@ -217,7 +218,18 @@ class TripRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeMember(tripId: String, memberId: String) {
-        api.removeMember(tripId, memberId).requireSuccess()
+        try {
+            api.removeMember(tripId, memberId).requireSuccess()
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueDelete(
+                entity = SyncEntities.TRIP_MEMBER,
+                id = "$tripId:$memberId",
+                payload = SyncTripMemberDeletePayload(
+                    tripId = tripId,
+                    memberId = memberId,
+                ),
+            )
+        }
         safeLocalMutation("removeMember.removeMember(tripId=$tripId, memberId=$memberId)") {
             tripMembersCacheStore.removeMember(tripId, memberId)
         }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/UserRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/UserRepositoryImpl.kt
@@ -8,9 +8,13 @@ import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.dto.UpdateUserRequest
 import nvk.cotrip.data.network.dto.UserDto
 import nvk.cotrip.data.network.requireSuccess
+import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.sync.SyncQueueRepository
+import nvk.cotrip.data.sync.SyncUserProfileUpsertPayload
 import nvk.cotrip.notifications.PushTokenSyncManager
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -18,6 +22,7 @@ class UserRepositoryImpl @Inject constructor(
     private val sessionCleaner: SessionCleaner,
     private val userCacheStore: UserCacheStore,
     private val pushTokenSyncManager: PushTokenSyncManager,
+    private val syncQueueRepository: SyncQueueRepository,
 ) : UserRepository {
 
     private companion object {
@@ -39,7 +44,37 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateMe(request: UpdateUserRequest): UserDto {
-        val user = api.updateMe(request)
+        val user = try {
+            api.updateMe(request)
+        } catch (e: IOException) {
+            syncQueueRepository.enqueueUpsert(
+                entity = SyncEntities.USER_PROFILE,
+                id = "me",
+                payload = SyncUserProfileUpsertPayload(
+                    name = request.name,
+                    photoUrl = request.photoUrl,
+                ),
+            )
+            val existing = runCatching { userCacheStore.getUser() }.getOrNull()
+            val local = if (existing != null) {
+                existing.copy(
+                    name = request.name,
+                    photoUrl = request.photoUrl,
+                    initials = initialsFromName(request.name),
+                )
+            } else {
+                UserDto(
+                    id = "me",
+                    name = request.name,
+                    photoUrl = request.photoUrl,
+                    initials = initialsFromName(request.name),
+                )
+            }
+            safeLocalMutation("updateMe.offlineSetUser") {
+                userCacheStore.setUser(local)
+            }
+            return local
+        }
         safeLocalMutation("updateMe.setUser") {
             userCacheStore.setUser(user)
         }
@@ -68,5 +103,14 @@ class UserRepositoryImpl @Inject constructor(
         }.onFailure {
             AppLogger.w(TAG, "clearSession cache clear failed", it)
         }
+    }
+}
+
+private fun initialsFromName(name: String): String {
+    val parts = name.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+    return when {
+        parts.isEmpty() -> "?"
+        parts.size == 1 -> parts[0].take(2).uppercase()
+        else -> "${parts[0].first()}${parts[1].first()}".uppercase()
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/sync/SyncChangeDao.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/sync/SyncChangeDao.kt
@@ -21,6 +21,15 @@ interface SyncChangeDao {
     @Query("DELETE FROM sync_changes WHERE entity = :entity AND entityId = :entityId")
     suspend fun deleteByEntity(entity: String, entityId: String)
 
+    @Query("DELETE FROM sync_changes WHERE entity = :entity")
+    suspend fun deleteAllByEntity(entity: String)
+
+    @Query("DELETE FROM sync_changes WHERE entity = :entity AND type = :type")
+    suspend fun deleteByEntityAndType(entity: String, type: String)
+
+    @Query("DELETE FROM sync_changes WHERE entity = :entity AND entityId = :entityId AND type = :type")
+    suspend fun deleteByEntityAndEntityIdAndType(entity: String, entityId: String, type: String)
+
     @Query(
         """
         SELECT EXISTS(

--- a/android/app/src/main/java/nvk/cotrip/data/sync/SyncCreatePayloads.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/sync/SyncCreatePayloads.kt
@@ -2,6 +2,7 @@ package nvk.cotrip.data.sync
 
 import kotlinx.serialization.Serializable
 import nvk.cotrip.data.network.dto.ExpenseParticipantInput
+import nvk.cotrip.data.network.dto.NotificationSettingDto
 
 @Serializable
 data class SyncTripCreateDayPayload(
@@ -58,4 +59,58 @@ data class SyncActivityCreatePayload(
     val costType: String? = null,
     val notes: String? = null,
     val orderIndex: Int? = null,
+)
+
+@Serializable
+data class SyncTripMemberDeletePayload(
+    val tripId: String,
+    val memberId: String,
+)
+
+@Serializable
+data class SyncIdeaStatusUpsertPayload(
+    val status: String,
+)
+
+@Serializable
+data class SyncIdeaConvertCreatePayload(
+    val dayId: String,
+    val timeText: String? = null,
+    val orderIndex: Int? = null,
+)
+
+@Serializable
+data class SyncActivityReorderUpsertPayload(
+    val dayId: String,
+    val orderedIds: List<String>,
+)
+
+@Serializable
+data class SyncItineraryTrimUpsertPayload(
+    val tripId: String,
+    val action: String,
+    val dayIds: List<String>,
+)
+
+@Serializable
+data class SyncNotificationSettingsUpsertPayload(
+    val items: List<NotificationSettingDto>,
+)
+
+@Serializable
+data class SyncNotificationReadUpsertPayload(
+    val mode: String,
+    val notificationId: String? = null,
+    val ideaId: String? = null,
+)
+
+@Serializable
+data class SyncUserProfileUpsertPayload(
+    val name: String,
+    val photoUrl: String? = null,
+)
+
+@Serializable
+data class SyncAiSuggestionSaveUpsertPayload(
+    val suggestionId: String,
 )

--- a/android/app/src/main/java/nvk/cotrip/data/sync/SyncEntities.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/sync/SyncEntities.kt
@@ -6,4 +6,13 @@ object SyncEntities {
     const val ACTIVITY = "activity"
     const val DAY = "day"
     const val EXPENSE = "expense"
+    const val TRIP_MEMBER = "trip_member"
+    const val IDEA_STATUS = "idea_status"
+    const val IDEA_CONVERT = "idea_convert"
+    const val ACTIVITY_REORDER = "activity_reorder"
+    const val ITINERARY_TRIM = "itinerary_trim"
+    const val NOTIFICATION_SETTINGS = "notification_settings"
+    const val NOTIFICATION_READ = "notification_read"
+    const val USER_PROFILE = "user_profile"
+    const val AI_SUGGESTION_SAVE = "ai_suggestion_save"
 }

--- a/android/app/src/main/java/nvk/cotrip/data/sync/SyncQueueRepository.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/sync/SyncQueueRepository.kt
@@ -15,22 +15,57 @@ class SyncQueueRepository @Inject constructor(
 ) {
     private val dao: SyncChangeDao = database.syncChangeDao()
 
+    companion object {
+        @PublishedApi
+        internal const val TYPE_CREATE = "create"
+        @PublishedApi
+        internal const val TYPE_UPSERT = "upsert"
+        @PublishedApi
+        internal val SINGLETON_COMMAND_UPSERT_ENTITIES = setOf(
+            SyncEntities.IDEA_STATUS,
+            SyncEntities.ACTIVITY_REORDER,
+            SyncEntities.ITINERARY_TRIM,
+            SyncEntities.NOTIFICATION_SETTINGS,
+            SyncEntities.NOTIFICATION_READ,
+            SyncEntities.USER_PROFILE,
+            SyncEntities.AI_SUGGESTION_SAVE,
+        )
+    }
+
     internal suspend inline fun <reified T> enqueueCreate(entity: String, id: String, payload: T) {
         val jsonPayload = json.encodeToJsonElement(payload).jsonObject
         enqueue(entity = entity, id = id, type = "create", payload = jsonPayload)
     }
 
     suspend fun enqueueDelete(entity: String, id: String) {
-        val hasPendingCreate = dao.hasPendingType(entity = entity, entityId = id, type = "create")
+        enqueueDeleteInternal(entity = entity, id = id, payload = null)
+    }
+
+    internal suspend inline fun <reified T> enqueueDelete(entity: String, id: String, payload: T) {
+        val jsonPayload = json.encodeToJsonElement(payload).jsonObject
+        enqueueDeleteInternal(entity = entity, id = id, payload = jsonPayload)
+    }
+
+    private suspend fun enqueueDeleteInternal(entity: String, id: String, payload: JsonObject?) {
+        val hasPendingCreate = dao.hasPendingType(entity = entity, entityId = id, type = TYPE_CREATE)
         if (hasPendingCreate) {
             dao.deleteByEntity(entity = entity, entityId = id)
             return
         }
-        enqueue(entity = entity, id = id, type = "delete", payload = null)
+        enqueue(entity = entity, id = id, type = "delete", payload = payload)
     }
 
     internal suspend inline fun <reified T> enqueueUpsert(entity: String, id: String, payload: T) {
         val jsonPayload = json.encodeToJsonElement(payload).jsonObject
+        if (entity in SINGLETON_COMMAND_UPSERT_ENTITIES) {
+            dao.deleteByEntityAndType(entity = entity, type = TYPE_UPSERT)
+        } else {
+            dao.deleteByEntityAndEntityIdAndType(
+                entity = entity,
+                entityId = id,
+                type = TYPE_UPSERT,
+            )
+        }
         enqueue(entity = entity, id = id, type = "upsert", payload = jsonPayload)
     }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
@@ -130,7 +130,6 @@ class ActivityDetailsViewModel @Inject constructor(
                 itineraryRepository.deleteActivity(activityId)
             }) {
                 is ApiResult.Success -> {
-                    emitToast(R.string.activity_details_deleted_toast)
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/form/CreateActivityViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/form/CreateActivityViewModel.kt
@@ -86,7 +86,7 @@ class CreateActivityViewModel @Inject constructor(
         when (event) {
             ActivityFormEvent.OnBackClick -> appNavigator.popBackStack()
             ActivityFormEvent.OnPrimaryClick -> createActivity()
-            ActivityFormEvent.OnDeleteClick -> emit(ActivityFormEffect.ShowToastRes(R.string.activity_form_delete_not_available))
+            ActivityFormEvent.OnDeleteClick -> Unit
             ActivityFormEvent.OnDismissLimitDialog -> _state.update { it.copy(limitDialog = null) }
             ActivityFormEvent.OnConfirmDeleteOldestAndRetry -> deleteOldestAndRetry()
             ActivityFormEvent.OnPickDateClick -> Unit
@@ -201,7 +201,6 @@ class CreateActivityViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ActivityFormEffect.ShowToastRes(R.string.activity_form_created_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -249,7 +248,6 @@ class CreateActivityViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ActivityFormEffect.ShowToastRes(R.string.activity_form_created_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/form/EditActivityViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/form/EditActivityViewModel.kt
@@ -208,7 +208,6 @@ class EditActivityViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ActivityFormEffect.ShowToastRes(R.string.activity_form_saved_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -285,7 +284,6 @@ class EditActivityViewModel @Inject constructor(
                 itineraryRepository.deleteActivity(activityId)
             }) {
                 is ApiResult.Success -> {
-                    emit(ActivityFormEffect.ShowToastRes(R.string.activity_form_deleted_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsViewModel.kt
@@ -153,7 +153,6 @@ class RouteSuggestionsViewModel @Inject constructor(
                             }
                         }
                     )
-                    emit(RouteSuggestionsEffect.ShowToastRes(R.string.ai_suggestions_saved))
                 }
 
                 is ApiResult.Failure -> {

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/form/CreateExpenseViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/form/CreateExpenseViewModel.kt
@@ -81,7 +81,7 @@ class CreateExpenseViewModel @Inject constructor(
         when (event) {
             ExpenseFormEvent.OnBackClick -> appNavigator.popBackStack()
             ExpenseFormEvent.OnPrimaryClick -> createExpense()
-            ExpenseFormEvent.OnDeleteClick -> emit(ExpenseFormEffect.ShowToastRes(R.string.expense_form_delete_not_available))
+            ExpenseFormEvent.OnDeleteClick -> Unit
             ExpenseFormEvent.OnDismissLimitDialog -> _state.update { it.copy(limitDialog = null) }
             ExpenseFormEvent.OnConfirmDeleteOldestAndRetry -> deleteOldestAndRetry()
             ExpenseFormEvent.OnDateClick -> Unit
@@ -231,7 +231,6 @@ class CreateExpenseViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ExpenseFormEffect.ShowToastRes(R.string.expense_form_created_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -280,7 +279,6 @@ class CreateExpenseViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ExpenseFormEffect.ShowToastRes(R.string.expense_form_created_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/form/EditExpenseViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/form/EditExpenseViewModel.kt
@@ -231,7 +231,6 @@ class EditExpenseViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(ExpenseFormEffect.ShowToastRes(R.string.expense_form_saved_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -249,7 +248,6 @@ class EditExpenseViewModel @Inject constructor(
                 expenseRepository.deleteExpense(expenseId)
             }) {
                 is ApiResult.Success -> {
-                    emit(ExpenseFormEffect.ShowToastRes(R.string.expense_form_deleted_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/list/TripExpensesViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/list/TripExpensesViewModel.kt
@@ -179,7 +179,9 @@ class TripExpensesViewModel @Inject constructor(
             }) {
                 is ApiResult.Success -> Unit
                 is ApiResult.Failure -> {
-                    _effects.emit(TripExpensesEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (isUserRefresh) {
+                        _effects.emit(TripExpensesEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                 }
             }
             isRefreshing.value = false

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
@@ -46,7 +46,7 @@ class TripForecastViewModel @Inject constructor(
     val effects = _effects.asSharedFlow()
 
     init {
-        refreshForecast(isUserRefresh = false, forceRefresh = true)
+        refreshForecast(isUserRefresh = false, forceRefresh = true, showErrorToast = false)
     }
 
     fun onEvent(event: TripForecastEvent) {
@@ -54,9 +54,13 @@ class TripForecastViewModel @Inject constructor(
             TripForecastEvent.OnBackClick -> appNavigator.popBackStack()
             TripForecastEvent.OnAutoRefresh -> refreshForecast(
                 isUserRefresh = false,
-                forceRefresh = true
+                forceRefresh = true,
+                showErrorToast = false,
             )
-            TripForecastEvent.OnUserRefresh -> refreshForecast(isUserRefresh = true)
+            TripForecastEvent.OnUserRefresh -> refreshForecast(
+                isUserRefresh = true,
+                showErrorToast = true,
+            )
             TripForecastEvent.OnCityClick -> {
                 val current = _state.value as? TripForecastState.Content ?: return
                 if (current.cityOptions.size > 1) {
@@ -74,7 +78,11 @@ class TripForecastViewModel @Inject constructor(
                     city = event.city,
                     isCityPickerVisible = false,
                 )
-                refreshForecast(isUserRefresh = false, forceRefresh = true)
+                refreshForecast(
+                    isUserRefresh = false,
+                    forceRefresh = true,
+                    showErrorToast = true,
+                )
             }
         }
     }
@@ -82,6 +90,7 @@ class TripForecastViewModel @Inject constructor(
     private fun refreshForecast(
         isUserRefresh: Boolean,
         forceRefresh: Boolean = false,
+        showErrorToast: Boolean = false,
     ) {
         viewModelScope.launch {
             val current = _state.value as? TripForecastState.Content
@@ -162,7 +171,9 @@ class TripForecastViewModel @Inject constructor(
                     if (latest != null) {
                         _state.value = latest.copy(isRefreshing = false)
                     }
-                    emitToast(uiErrorMapper.messageRes(result))
+                    if (showErrorToast) {
+                        emitToast(uiErrorMapper.messageRes(result))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
@@ -397,7 +397,6 @@ class IdeaDetailsViewModel @Inject constructor(
                 is ApiResult.Success -> {
                     itineraryRepository.refreshItinerary(tripId).getOrThrow()
                     _state.update { it.copy(addedDay = day.dayNumber) }
-                    emit(IdeaDetailsEffect.ShowToastRes(R.string.idea_details_added_toast))
                 }
 
                 is ApiResult.Failure -> {
@@ -592,12 +591,6 @@ class IdeaDetailsViewModel @Inject constructor(
                 is ApiResult.Success -> {
                     val idea = result.data
                     _state.update { it.copy(status = idea.status, isUpdatingStatus = false) }
-                    val toast = if (approved) {
-                        R.string.idea_details_approved_toast
-                    } else {
-                        R.string.idea_details_rejected_toast
-                    }
-                    emit(IdeaDetailsEffect.ShowToastRes(toast))
                 }
 
                 is ApiResult.Failure -> {
@@ -614,7 +607,6 @@ class IdeaDetailsViewModel @Inject constructor(
                 ideaRepository.deleteIdea(ideaId)
             }) {
                 is ApiResult.Success -> {
-                    emit(IdeaDetailsEffect.ShowToastRes(R.string.idea_details_deleted_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/form/CreateIdeaViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/form/CreateIdeaViewModel.kt
@@ -75,7 +75,7 @@ class CreateIdeaViewModel @Inject constructor(
         when (event) {
             IdeaFormEvent.OnBackClick -> appNavigator.popBackStack()
             IdeaFormEvent.OnPrimaryClick -> createIdea()
-            IdeaFormEvent.OnDeleteClick -> emit(IdeaFormEffect.ShowToastRes(R.string.idea_form_delete_not_available))
+            IdeaFormEvent.OnDeleteClick -> Unit
             IdeaFormEvent.OnDismissLimitDialog -> _state.update { it.copy(limitDialog = null) }
             IdeaFormEvent.OnConfirmDeleteOldestAndRetry -> deleteOldestAndRetry()
             is IdeaFormEvent.OnCitySelected -> onCitySuggestionSelected(event.city)
@@ -201,7 +201,6 @@ class CreateIdeaViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(IdeaFormEffect.ShowToastRes(R.string.idea_form_created_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -247,7 +246,6 @@ class CreateIdeaViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(IdeaFormEffect.ShowToastRes(R.string.idea_form_created_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/form/EditIdeaViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/form/EditIdeaViewModel.kt
@@ -221,7 +221,6 @@ class EditIdeaViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    emit(IdeaFormEffect.ShowToastRes(R.string.idea_form_saved_toast))
                     appNavigator.popBackStack()
                 }
 
@@ -239,7 +238,6 @@ class EditIdeaViewModel @Inject constructor(
                 ideaRepository.deleteIdea(ideaId)
             }) {
                 is ApiResult.Success -> {
-                    emit(IdeaFormEffect.ShowToastRes(R.string.idea_form_deleted_toast))
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/list/TripIdeasViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/list/TripIdeasViewModel.kt
@@ -155,13 +155,15 @@ class TripIdeasViewModel @Inject constructor(
                 itineraryRepository.refreshItinerary(tripId).getOrThrow()
             }) {
                 is ApiResult.Success -> Unit
-                is ApiResult.Failure -> emit(
-                    TripIdeasEffect.ShowToastRes(
-                        uiErrorMapper.messageRes(
-                            result
+                is ApiResult.Failure -> if (isUserRefresh) {
+                    emit(
+                        TripIdeasEffect.ShowToastRes(
+                            uiErrorMapper.messageRes(
+                                result
+                            )
                         )
-                        )
-                )
+                    )
+                }
             }
             isRefreshing.value = false
         }
@@ -201,7 +203,6 @@ class TripIdeasViewModel @Inject constructor(
                         }
                     )
                     itineraryRepository.refreshItinerary(tripId).getOrThrow()
-                    emit(TripIdeasEffect.ShowToastRes(R.string.ideas_added_to_itinerary_toast))
                 }
 
                 is ApiResult.Failure -> emit(

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleViewModel.kt
@@ -50,7 +50,6 @@ class InvitePeopleViewModel @Inject constructor(
                 val link = (_state.value as? InvitePeopleState.Content)?.inviteLink.orEmpty()
                 if (link.isNotBlank()) {
                     emit(InvitePeopleEffect.CopyToClipboard(link))
-                    emitToast(R.string.invite_people_copied_toast)
                 }
             }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripScreen.kt
@@ -40,11 +40,13 @@ fun JoinTripScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
-    val inviteErrorText = if (state.inviteInput.isNotBlank() && !state.isInviteValid) {
-        stringResource(R.string.join_trip_invalid)
-    } else {
-        null
-    }
+    val inlineErrorRes = state.inlineErrorRes
+        ?: if (state.inviteInput.isNotBlank() && !state.isInviteValid) {
+            R.string.join_trip_invalid
+        } else {
+            null
+        }
+    val inviteErrorText = inlineErrorRes?.let { stringResource(it) }
 
     LaunchedEffect(viewModel) {
         viewModel.effects.collectLatest { effect ->

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripState.kt
@@ -4,4 +4,5 @@ data class JoinTripState(
     val inviteInput: String,
     val isLoading: Boolean,
     val isInviteValid: Boolean,
+    val inlineErrorRes: Int? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripViewModel.kt
@@ -48,6 +48,7 @@ class JoinTripViewModel @Inject constructor(
             inviteInput = "",
             isLoading = false,
             isInviteValid = false,
+            inlineErrorRes = null,
         )
     )
     val state = _state.asStateFlow()
@@ -81,6 +82,7 @@ class JoinTripViewModel @Inject constructor(
                     it.copy(
                         inviteInput = input,
                         isInviteValid = isValid,
+                        inlineErrorRes = null,
                     )
                 }
             }
@@ -91,13 +93,13 @@ class JoinTripViewModel @Inject constructor(
     private fun joinTrip(targetOverride: JoinTarget? = null) {
         val target = targetOverride ?: parseJoinTarget(_state.value.inviteInput)
         if (target == null) {
-            emit(JoinTripEffect.ShowToastRes(R.string.join_trip_invalid))
+            _state.update { it.copy(inlineErrorRes = R.string.join_trip_invalid) }
             return
         }
         if (_state.value.isLoading) return
 
         viewModelScope.launch {
-            _state.update { it.copy(isLoading = true) }
+            _state.update { it.copy(isLoading = true, inlineErrorRes = null) }
             val preflight = apiCaller.call {
                 runCatching { tripRepository.refreshTrips() }
                 val joinedIds = tripRepository.trips.first().mapTo(mutableSetOf()) { it.id }
@@ -113,8 +115,12 @@ class JoinTripViewModel @Inject constructor(
             when (preflight) {
                 is ApiResult.Success -> {
                     if (preflight.data) {
-                        _state.update { it.copy(isLoading = false) }
-                        emit(JoinTripEffect.ShowToastRes(R.string.join_trip_already_joined))
+                        _state.update {
+                            it.copy(
+                                isLoading = false,
+                                inlineErrorRes = R.string.join_trip_already_joined,
+                            )
+                        }
                         return@launch
                     }
                 }
@@ -144,7 +150,6 @@ class JoinTripViewModel @Inject constructor(
                 is ApiResult.Success -> {
                     val tripId = result.data
                     _state.update { it.copy(isLoading = false) }
-                    emit(JoinTripEffect.ShowToastRes(R.string.join_trip_success))
                     appNavigator.navigate(Destination.TripDetails(tripId)) {
                         popUpTo(Destination.Trips.route) { inclusive = false }
                         launchSingleTop = true

--- a/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryScreen.kt
@@ -231,6 +231,16 @@ fun TripItineraryScreen(
                             )
                         }
                     }
+                    state.inlineErrorRes?.let { inlineError ->
+                        item(key = "required_cities_inline_error") {
+                            Text(
+                                text = stringResource(inlineError),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
                 }
 
                 when (state.mode) {

--- a/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryState.kt
@@ -1,5 +1,7 @@
 package nvk.cotrip.ui.itinerary
 
+import androidx.annotation.StringRes
+
 data class TripItineraryState(
     val tripId: String,
     val dateRange: String,
@@ -10,4 +12,5 @@ data class TripItineraryState(
     val isCitySelectionRequired: Boolean,
     val pendingCitySelectionCount: Int,
     val isRefreshing: Boolean = false,
+    @StringRes val inlineErrorRes: Int? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryViewModel.kt
@@ -95,7 +95,7 @@ class TripItineraryViewModel @Inject constructor(
                     return
                 }
                 if (_state.value.isCitySelectionRequired && _state.value.pendingCitySelectionCount > 0) {
-                    emitToast(R.string.itinerary_city_setup_required_toast)
+                    _state.update { it.copy(inlineErrorRes = R.string.itinerary_city_setup_required_toast) }
                 } else {
                     appNavigator.popBackStack()
                 }
@@ -120,6 +120,7 @@ class TripItineraryViewModel @Inject constructor(
 
             is TripItineraryEvent.OnChooseCityClick -> {
                 if (_state.value.isPastTrip) return
+                _state.update { it.copy(inlineErrorRes = null) }
                 openCityPicker(event.dayId)
             }
 
@@ -214,6 +215,15 @@ class TripItineraryViewModel @Inject constructor(
                             } else {
                                 0
                             },
+                            inlineErrorRes = if (
+                                requireCitySelection &&
+                                !isPastTrip &&
+                                pendingCitySelectionCount > 0
+                            ) {
+                                it.inlineErrorRes
+                            } else {
+                                null
+                            },
                         )
                     }
                 }
@@ -244,7 +254,9 @@ class TripItineraryViewModel @Inject constructor(
                         delay(400)
                         refreshItinerary(isUserRefresh = false)
                     } else {
-                        emitToast(uiErrorMapper.messageRes(result))
+                        if (isUserRefresh) {
+                            emitToast(uiErrorMapper.messageRes(result))
+                        }
                     }
                 }
             }
@@ -515,7 +527,6 @@ class TripItineraryViewModel @Inject constructor(
                     cityName = selectedCityName,
                 )
                 runCatching { itineraryRepository.refreshItinerary(tripId).getOrThrow() }
-                emitToast(R.string.itinerary_choose_city_applied_following_toast)
             } else if (firstFailure != null) {
                 emitToast(uiErrorMapper.messageRes(checkNotNull(firstFailure)))
             } else {
@@ -586,7 +597,7 @@ class TripItineraryViewModel @Inject constructor(
         val current = _state.value
         if (!current.isCitySelectionRequired) return
         if (current.pendingCitySelectionCount > 0) {
-            emitToast(R.string.itinerary_city_setup_required_toast)
+            _state.update { it.copy(inlineErrorRes = R.string.itinerary_city_setup_required_toast) }
             return
         }
         viewModelScope.launch {

--- a/android/app/src/main/java/nvk/cotrip/ui/outofrangedays/OutOfRangeDaysViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/outofrangedays/OutOfRangeDaysViewModel.kt
@@ -114,12 +114,6 @@ class OutOfRangeDaysViewModel @Inject constructor(
                 )
             }) {
                 is ApiResult.Success -> {
-                    val toast = when (action) {
-                        "extend_end" -> R.string.out_of_range_days_extended_toast
-                        "remove" -> R.string.out_of_range_days_removed_toast
-                        else -> R.string.out_of_range_days_kept_toast
-                    }
-                    emitToast(toast)
                     appNavigator.popBackStack()
                 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/settings/SettingsViewModel.kt
@@ -293,7 +293,6 @@ class SettingsViewModel @Inject constructor(
             when (result) {
                 is ApiResult.Success -> {
                     userRepository.clearSession()
-                    emit(SettingsEffect.ShowToastRes(R.string.settings_profile_deleted_toast))
                     appNavigator.navigate(Destination.SignIn) {
                         popUpTo(Destination.Trips.route) { inclusive = true }
                         launchSingleTop = true
@@ -330,7 +329,6 @@ class SettingsViewModel @Inject constructor(
                             canSave = canSaveProfileChanges(updatedProfile.name, updatedProfile.photoUrl)
                         )
                     }
-                    emit(SettingsEffect.ShowToastRes(R.string.settings_photo_changed_toast))
                 }
 
                 is ApiResult.Failure -> {

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/details/TripDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/details/TripDetailsViewModel.kt
@@ -334,7 +334,9 @@ class TripDetailsViewModel @Inject constructor(
                         "refreshTripData failed for tripId=$tripId code=${result.httpCode} apiCode=${result.error?.code.orEmpty()}",
                         result.cause
                     )
-                    emitToast(uiErrorMapper.messageRes(result))
+                    if (isUserRefresh) {
+                        emitToast(uiErrorMapper.messageRes(result))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/form/CreateTripViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/form/CreateTripViewModel.kt
@@ -66,23 +66,33 @@ class CreateTripViewModel @Inject constructor(
             }
 
             is TripFormEvent.OnNameChange -> {
-                _state.update { it.copy(name = event.value.take(TextInputLimits.TRIP_TITLE)) }
+                _state.update {
+                    it.copy(
+                        name = event.value.take(TextInputLimits.TRIP_TITLE),
+                        inlineErrorRes = null,
+                    )
+                }
                 recomputeCanSubmit()
             }
 
             is TripFormEvent.OnStartDateSelected -> {
                 if (!TripDateRules.isStartDateAllowed(event.date, LocalDate.now())) {
-                    emitToastRes(R.string.trip_form_start_date_range_toast)
+                    _state.update {
+                        it.copy(
+                            startDateErrorRes = R.string.trip_form_start_date_range_toast,
+                            endDateErrorRes = null,
+                        )
+                    }
                     return
                 }
-                _state.update { it.copy(startDate = event.date) }
+                _state.update { it.copy(startDate = event.date, startDateErrorRes = null) }
                 val selectedEnd = _state.value.endDate
                 if (selectedEnd != null && !TripDateRules.isEndDateAllowed(
                         event.date,
                         selectedEnd
                     )
                 ) {
-                    emitToastRes(R.string.trip_form_end_date_range_toast)
+                    _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                 }
                 recomputeCanSubmit()
             }
@@ -91,10 +101,10 @@ class CreateTripViewModel @Inject constructor(
                 val selectedStart = _state.value.startDate
                 val start = selectedStart ?: LocalDate.now()
                 if (!TripDateRules.isEndDateAllowed(startDate = start, endDate = event.date)) {
-                    emitToastRes(R.string.trip_form_end_date_range_toast)
+                    _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                     return
                 }
-                _state.update { it.copy(endDate = event.date) }
+                _state.update { it.copy(endDate = event.date, endDateErrorRes = null) }
                 recomputeCanSubmit()
             }
 
@@ -153,14 +163,26 @@ class CreateTripViewModel @Inject constructor(
             val startDate = s.startDate ?: return@launch
             val endDate = s.endDate ?: return@launch
             if (!TripDateRules.isStartDateAllowed(startDate, LocalDate.now())) {
-                emitToastRes(R.string.trip_form_start_date_range_toast)
+                _state.update {
+                    it.copy(
+                        startDateErrorRes = R.string.trip_form_start_date_range_toast,
+                        endDateErrorRes = null,
+                    )
+                }
                 return@launch
             }
             if (!TripDateRules.isEndDateAllowed(startDate = startDate, endDate = endDate)) {
-                emitToastRes(R.string.trip_form_end_date_range_toast)
+                _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                 return@launch
             }
-            _state.update { it.copy(isLoading = true) }
+            _state.update {
+                it.copy(
+                    isLoading = true,
+                    startDateErrorRes = null,
+                    endDateErrorRes = null,
+                    inlineErrorRes = null,
+                )
+            }
             val request = CreateTripRequest(
                 title = s.name,
                 description = s.description.takeIf { it.isNotBlank() },
@@ -183,7 +205,6 @@ class CreateTripViewModel @Inject constructor(
                 is ApiResult.Success -> {
                     AppLogger.i(TAG, "createTrip succeeded tripId=${result.data}")
                     markTripCreationPending(result.data)
-                    emitToastRes(R.string.create_trip_created_toast)
                     appNavigator.navigate(
                         Destination.TripItinerary(
                             tripId = result.data,
@@ -217,7 +238,6 @@ class CreateTripViewModel @Inject constructor(
                     if (recoveredTripId != null) {
                         AppLogger.i(TAG, "createTrip recovered via listTrips tripId=$recoveredTripId")
                         markTripCreationPending(recoveredTripId)
-                        emitToastRes(R.string.create_trip_created_toast)
                         appNavigator.navigate(
                             Destination.TripItinerary(
                                 tripId = recoveredTripId,
@@ -246,7 +266,6 @@ class CreateTripViewModel @Inject constructor(
             }) {
                 is ApiResult.Success -> {
                     markTripCreationPending(result.data)
-                    emitToastRes(R.string.create_trip_created_toast)
                     appNavigator.navigate(
                         Destination.TripItinerary(
                             tripId = result.data,
@@ -317,7 +336,6 @@ class CreateTripViewModel @Inject constructor(
                             coverPreviewUri = result.data,
                         )
                     }
-                    emitToastRes(R.string.trip_form_cover_uploaded_toast)
                 }
 
                 is ApiResult.Failure -> {

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/form/EditTripViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/form/EditTripViewModel.kt
@@ -68,13 +68,23 @@ class EditTripViewModel @Inject constructor(
             }
 
             is TripFormEvent.OnNameChange -> {
-                _state.update { it.copy(name = event.value.take(TextInputLimits.TRIP_TITLE)) }
+                _state.update {
+                    it.copy(
+                        name = event.value.take(TextInputLimits.TRIP_TITLE),
+                        inlineErrorRes = null,
+                    )
+                }
                 recomputeCanSubmit()
             }
 
             is TripFormEvent.OnStartDateSelected -> {
                 if (!isStartDateAllowedForEdit(event.date)) {
-                    emitToastRes(R.string.trip_form_start_date_range_toast)
+                    _state.update {
+                        it.copy(
+                            startDateErrorRes = R.string.trip_form_start_date_range_toast,
+                            endDateErrorRes = null,
+                        )
+                    }
                     return
                 }
                 val previousStart = _state.value.startDate
@@ -92,6 +102,7 @@ class EditTripViewModel @Inject constructor(
                     current.copy(
                         startDate = event.date,
                         endDate = adjustedEnd,
+                        startDateErrorRes = null,
                     )
                 }
 
@@ -102,7 +113,7 @@ class EditTripViewModel @Inject constructor(
                     )
                 ) {
                     if (!isOriginalDatesPair(event.date, selectedEnd)) {
-                        emitToastRes(R.string.trip_form_end_date_range_toast)
+                        _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                     }
                 }
                 recomputeCanSubmit()
@@ -114,10 +125,10 @@ class EditTripViewModel @Inject constructor(
                 if (!TripDateRules.isEndDateAllowed(startDate = start, endDate = event.date) &&
                     !isOriginalDatesPair(start, event.date)
                 ) {
-                    emitToastRes(R.string.trip_form_end_date_range_toast)
+                    _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                     return
                 }
-                _state.update { it.copy(endDate = event.date) }
+                _state.update { it.copy(endDate = event.date, endDateErrorRes = null) }
                 recomputeCanSubmit()
             }
 
@@ -229,13 +240,25 @@ class EditTripViewModel @Inject constructor(
                     TripDateRules.isEndDateAllowed(startDate = startDate, endDate = endDate)
             if (!strictDatesOk && !isOriginalDatesPair(startDate, endDate)) {
                 if (!isStartDateAllowedForEdit(startDate)) {
-                    emitToastRes(R.string.trip_form_start_date_range_toast)
+                    _state.update {
+                        it.copy(
+                            startDateErrorRes = R.string.trip_form_start_date_range_toast,
+                            endDateErrorRes = null,
+                        )
+                    }
                 } else {
-                    emitToastRes(R.string.trip_form_end_date_range_toast)
+                    _state.update { it.copy(endDateErrorRes = R.string.trip_form_end_date_range_toast) }
                 }
                 return@launch
             }
-            _state.update { it.copy(isLoading = true) }
+            _state.update {
+                it.copy(
+                    isLoading = true,
+                    startDateErrorRes = null,
+                    endDateErrorRes = null,
+                    inlineErrorRes = null,
+                )
+            }
 
             val result = apiCaller.call {
                 tripRepository.updateTrip(
@@ -259,7 +282,6 @@ class EditTripViewModel @Inject constructor(
                         _state.update { it.copy(isLoading = false) }
                         return@launch
                     }
-                    emitToastRes(R.string.edit_trip_saved_toast)
                     val oldStart = originalStartDate ?: startDate
                     val oldEnd = originalEndDate ?: endDate
                     val oldDuration = ChronoUnit.DAYS.between(oldStart, oldEnd)
@@ -305,7 +327,6 @@ class EditTripViewModel @Inject constructor(
             }
             when (result) {
                 is ApiResult.Success -> {
-                    emitToastRes(R.string.edit_trip_archived_toast)
                     closeScreen()
                 }
 
@@ -325,7 +346,6 @@ class EditTripViewModel @Inject constructor(
             }
             when (result) {
                 is ApiResult.Success -> {
-                    emitToastRes(R.string.edit_trip_deleted_toast)
                     appNavigator.navigate(Destination.Trips) {
                         popUpTo(Destination.Trips.route) { inclusive = false }
                         launchSingleTop = true
@@ -355,7 +375,6 @@ class EditTripViewModel @Inject constructor(
                             coverPreviewUri = result.data,
                         )
                     }
-                    emitToastRes(R.string.trip_form_cover_uploaded_toast)
                 }
 
                 is ApiResult.Failure -> {

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/form/TripFormHost.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/form/TripFormHost.kt
@@ -229,6 +229,16 @@ private fun TripFormScreen(
                     modifier = Modifier.fillMaxWidth()
                 )
 
+                state.inlineErrorRes?.let { inlineError ->
+                    Spacer(Modifier.height(CoTripTokens.spacing.x1))
+                    Text(
+                        text = stringResource(inlineError),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
                 Spacer(Modifier.height(CoTripTokens.spacing.x2))
 
                 TertiaryTextButton(
@@ -296,6 +306,26 @@ private fun TripFormScreen(
                         valueText = formatDateOrPlaceholder(state.endDate),
                         onClick = onEndDateClick,
                         modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
+            state.startDateErrorRes?.let { startDateError ->
+                item {
+                    Text(
+                        text = stringResource(startDateError),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+
+            state.endDateErrorRes?.let { endDateError ->
+                item {
+                    Text(
+                        text = stringResource(endDateError),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
                     )
                 }
             }

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/form/TripFormState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/form/TripFormState.kt
@@ -1,6 +1,7 @@
 package nvk.cotrip.ui.trip.form
 
 import nvk.cotrip.ui.common.LimitDialogState
+import androidx.annotation.StringRes
 import java.time.LocalDate
 
 data class TripFormState(
@@ -15,4 +16,7 @@ data class TripFormState(
     val availableCurrencies: List<TripCurrency> = TripCurrency.entries,
     val canSubmit: Boolean = false,
     val limitDialog: LimitDialogState? = null,
+    @StringRes val startDateErrorRes: Int? = null,
+    @StringRes val endDateErrorRes: Int? = null,
+    @StringRes val inlineErrorRes: Int? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/list/TripsListViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/list/TripsListViewModel.kt
@@ -114,14 +114,16 @@ class TripsListViewModel @Inject constructor(
 
             val result = tripRepository.refreshTrips()
             val syncResult = syncPullRepository.pull()
-            if (result.isFailure) {
-                _effects.tryEmit(
-                    TripsListEffect.ShowToast(appContext.getString(R.string.trips_list_load_failed))
-                )
-            } else if (syncResult.isFailure) {
-                _effects.tryEmit(
-                    TripsListEffect.ShowToast(appContext.getString(R.string.trips_list_sync_failed))
-                )
+            if (isUserRefresh) {
+                if (result.isFailure) {
+                    _effects.tryEmit(
+                        TripsListEffect.ShowToast(appContext.getString(R.string.trips_list_load_failed))
+                    )
+                } else if (syncResult.isFailure) {
+                    _effects.tryEmit(
+                        TripsListEffect.ShowToast(appContext.getString(R.string.trips_list_sync_failed))
+                    )
+                }
             }
             isRefreshing.value = false
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/members/TripMembersViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/members/TripMembersViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.ApiResult
 import nvk.cotrip.data.repository.TripRepository
@@ -138,13 +137,10 @@ class TripMembersViewModel @Inject constructor(
                         _state.value = latest.copy(isLoadingAction = false)
                     }
                     if (isSelf) {
-                        emit(TripMembersEffect.ShowToastRes(R.string.trip_members_left_toast))
                         appNavigator.navigate(Destination.Trips) {
                             popUpTo(Destination.Trips.route) { inclusive = true }
                             launchSingleTop = true
                         }
-                    } else {
-                        emit(TripMembersEffect.ShowToastRes(R.string.trip_members_removed_toast))
                     }
                 }
                 is ApiResult.Failure -> {

--- a/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
@@ -5,16 +5,19 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import nvk.cotrip.data.auth.SessionCleaner
 import nvk.cotrip.data.cache.ExpensesCacheStore
 import nvk.cotrip.data.cache.IdeaCommentsCacheStore
 import nvk.cotrip.data.cache.IdeasCacheStore
 import nvk.cotrip.data.cache.ItineraryCacheStore
+import nvk.cotrip.data.cache.NotificationsCacheStore
 import nvk.cotrip.data.cache.TripMembersCacheStore
 import nvk.cotrip.data.cache.TripsCacheStore
 import nvk.cotrip.data.cache.UserCacheStore
@@ -22,21 +25,30 @@ import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.data.network.dto.ActivityDto
 import nvk.cotrip.data.network.dto.CommentDto
+import nvk.cotrip.data.network.dto.ConvertIdeaRequest
 import nvk.cotrip.data.network.dto.CreateActivityRequest
 import nvk.cotrip.data.network.dto.CreateIdeaRequest
 import nvk.cotrip.data.network.dto.CreateTripRequest
 import nvk.cotrip.data.network.dto.ExpenseCreateRequest
 import nvk.cotrip.data.network.dto.ExpenseDto
+import nvk.cotrip.data.network.dto.ExpenseParticipantDto
 import nvk.cotrip.data.network.dto.ExpenseParticipantInput
+import nvk.cotrip.data.network.dto.ExpenseUpdateRequest
 import nvk.cotrip.data.network.dto.IdeaDto
 import nvk.cotrip.data.network.dto.ItineraryDayDto
 import nvk.cotrip.data.network.dto.MemberDto
+import nvk.cotrip.data.network.dto.NotificationDto
+import nvk.cotrip.data.network.dto.NotificationSettingDto
+import nvk.cotrip.data.network.dto.TrimOutOfRangeRequest
 import nvk.cotrip.data.network.dto.TripDto
+import nvk.cotrip.data.network.dto.UpdateTripRequest
+import nvk.cotrip.data.network.dto.UpdateUserRequest
 import nvk.cotrip.data.network.dto.UserDto
 import nvk.cotrip.data.sync.CoTripDatabase
 import nvk.cotrip.data.sync.SyncEntities
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.data.sync.SyncScheduler
+import nvk.cotrip.notifications.PushTokenSyncManager
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -132,6 +144,7 @@ class OfflineCreateRepositoriesTest {
             syncQueueRepository = queue,
             ideasCacheStore = ideasStore,
             commentsCacheStore = FakeIdeaCommentsCacheStore(),
+            itineraryCacheStore = FakeItineraryCacheStore(),
             userCacheStore = userStore,
             networkStateProvider = networkStateProvider,
         )
@@ -260,6 +273,425 @@ class OfflineCreateRepositoriesTest {
         assertEquals(SyncEntities.ACTIVITY, pending.first().entity)
         assertEquals("create", pending.first().type)
         assertEquals(created.id, pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_updateTrip_then_updatesLocalTripAndQueuesUpsertAndReturnsSuccess() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.updateTrip(any(), any()) } throws IOException("offline")
+        val tripsStore = FakeTripsCacheStore().apply {
+            upsertTrip(
+                TripDto(
+                    id = "trip-1",
+                    ownerId = "owner-1",
+                    title = "Before",
+                    description = "desc",
+                    startDate = "2026-06-10",
+                    endDate = "2026-06-12",
+                    locationLine = "Rome",
+                    coverUrl = null,
+                    currencyCode = "EUR",
+                    status = "active",
+                    updatedAt = "2026-01-01T00:00:00Z",
+                )
+            )
+        }
+        val repository = TripRepositoryImpl(
+            api = api,
+            tripsCacheStore = tripsStore,
+            tripMembersCacheStore = FakeTripMembersCacheStore(),
+            itineraryCacheStore = FakeItineraryCacheStore(),
+            userCacheStore = FakeUserCacheStore(),
+            syncQueueRepository = queue,
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        val result = repository.updateTrip(
+            tripId = "trip-1",
+            request = UpdateTripRequest(
+                title = "After",
+            )
+        )
+
+        // THEN
+        assertTrue(result.isSuccess)
+        assertEquals("After", tripsStore.getTrips().first { it.id == "trip-1" }.title)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.TRIP, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("trip-1", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_removeMember_then_updatesLocalMembersAndQueuesDeleteCommand() = runTest {
+        // GIVEN
+        val tripId = "trip-members-1"
+        val api = mockk<CoTripApi>()
+        coEvery { api.removeMember(any(), any()) } throws IOException("offline")
+        val membersStore = FakeTripMembersCacheStore().apply {
+            setMembers(
+                tripId = tripId,
+                members = listOf(
+                    MemberDto(
+                        userId = "member-1",
+                        name = "Member 1",
+                        initials = "M1",
+                        role = "owner",
+                        status = "joined",
+                    ),
+                    MemberDto(
+                        userId = "member-2",
+                        name = "Member 2",
+                        initials = "M2",
+                        role = "member",
+                        status = "joined",
+                    ),
+                )
+            )
+        }
+        val repository = TripRepositoryImpl(
+            api = api,
+            tripsCacheStore = FakeTripsCacheStore(),
+            tripMembersCacheStore = membersStore,
+            itineraryCacheStore = FakeItineraryCacheStore(),
+            userCacheStore = FakeUserCacheStore(),
+            syncQueueRepository = queue,
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        repository.removeMember(tripId = tripId, memberId = "member-2")
+
+        // THEN
+        assertEquals(1, membersStore.getMembers(tripId).size)
+        assertEquals("member-1", membersStore.getMembers(tripId).first().userId)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.TRIP_MEMBER, pending.first().entity)
+        assertEquals("delete", pending.first().type)
+        assertEquals("$tripId:member-2", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_approveIdea_then_updatesLocalStatusAndQueuesStatusCommand() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.approveIdea(any()) } throws IOException("offline")
+        val ideasStore = FakeIdeasCacheStore().apply {
+            setIdeas(
+                tripId = "trip-approve",
+                ideas = listOf(
+                    IdeaDto(
+                        id = "idea-approve-1",
+                        tripId = "trip-approve",
+                        authorId = "user-1",
+                        title = "Idea",
+                        status = "pending",
+                        updatedAt = "2026-01-01T00:00:00Z",
+                        commentsCount = 0,
+                    )
+                )
+            )
+        }
+        val repository = IdeaRepositoryImpl(
+            api = api,
+            syncQueueRepository = queue,
+            ideasCacheStore = ideasStore,
+            commentsCacheStore = FakeIdeaCommentsCacheStore(),
+            itineraryCacheStore = FakeItineraryCacheStore(),
+            userCacheStore = FakeUserCacheStore(),
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        val approved = repository.approveIdea("idea-approve-1")
+
+        // THEN
+        assertEquals("approved", approved.status)
+        assertEquals(
+            "approved",
+            ideasStore.findIdeaById("idea-approve-1")?.status
+        )
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.IDEA_STATUS, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("idea-approve-1", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_convertIdea_then_updatesLocalItineraryAndQueuesConvertCommand() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.convertIdeaToActivity(any(), any()) } throws IOException("offline")
+        val tripId = "trip-convert-1"
+        val dayId = "day-convert-1"
+        val ideasStore = FakeIdeasCacheStore().apply {
+            setIdeas(
+                tripId = tripId,
+                ideas = listOf(
+                    IdeaDto(
+                        id = "idea-convert-1",
+                        tripId = tripId,
+                        authorId = "user-1",
+                        title = "Convert me",
+                        city = "Paris",
+                        link = "https://example.com",
+                        costAmount = 20.0,
+                        costType = "per_person",
+                        notes = "note",
+                        status = "pending",
+                        updatedAt = "2026-01-01T00:00:00Z",
+                        commentsCount = 0,
+                    )
+                )
+            )
+        }
+        val itineraryStore = FakeItineraryCacheStore().apply {
+            setItinerary(
+                tripId = tripId,
+                days = listOf(
+                    ItineraryDayDto(
+                        id = dayId,
+                        tripId = tripId,
+                        date = "2026-06-10",
+                        dayNumber = 1,
+                        city = "Paris",
+                        cityProviderId = null,
+                        cityLat = null,
+                        cityLon = null,
+                        isOutOfRange = false,
+                        activities = emptyList(),
+                    )
+                )
+            )
+        }
+        val repository = IdeaRepositoryImpl(
+            api = api,
+            syncQueueRepository = queue,
+            ideasCacheStore = ideasStore,
+            commentsCacheStore = FakeIdeaCommentsCacheStore(),
+            itineraryCacheStore = itineraryStore,
+            userCacheStore = FakeUserCacheStore(),
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        repository.convertIdeaToActivity(
+            ideaId = "idea-convert-1",
+            request = ConvertIdeaRequest(dayId = dayId),
+        )
+
+        // THEN
+        val activities = itineraryStore.getItinerary(tripId).first { it.id == dayId }.activities
+        assertEquals(1, activities.size)
+        assertEquals("idea-convert-1", activities.first().sourceIdeaId)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.IDEA_CONVERT, pending.first().entity)
+        assertEquals("create", pending.first().type)
+        assertEquals("idea-convert-1", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_updateExpense_then_updatesLocalExpenseAndQueuesUpsert() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.updateExpense(any(), any()) } throws IOException("offline")
+        val expensesStore = FakeExpensesCacheStore().apply {
+            setExpenses(
+                tripId = "trip-expense-update",
+                expenses = listOf(
+                    ExpenseDto(
+                        id = "expense-1",
+                        tripId = "trip-expense-update",
+                        title = "Before",
+                        amount = 10.0,
+                        currencyCode = "EUR",
+                        status = "planned",
+                        splitType = "equally",
+                        participants = listOf(
+                            ExpenseParticipantDto(
+                                userId = "user-1",
+                                isIncluded = true,
+                                isPaid = false,
+                            )
+                        ),
+                    )
+                )
+            )
+        }
+        val repository = ExpenseRepositoryImpl(
+            api = api,
+            syncQueueRepository = queue,
+            expensesCacheStore = expensesStore,
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        repository.updateExpense(
+            expenseId = "expense-1",
+            request = ExpenseUpdateRequest(title = "After"),
+        )
+
+        // THEN
+        assertEquals("After", expensesStore.findExpenseById("expense-1")?.title)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.EXPENSE, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("expense-1", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_trimOutOfRange_then_updatesLocalItineraryAndQueuesCommand() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.trimOutOfRangeDays(any(), any()) } throws IOException("offline")
+        val tripId = "trip-trim-1"
+        val itineraryStore = FakeItineraryCacheStore().apply {
+            setItinerary(
+                tripId = tripId,
+                days = listOf(
+                    ItineraryDayDto(
+                        id = "day-trim-1",
+                        tripId = tripId,
+                        date = "2026-06-10",
+                        dayNumber = 1,
+                        city = null,
+                        cityProviderId = null,
+                        cityLat = null,
+                        cityLon = null,
+                        isOutOfRange = false,
+                        activities = emptyList(),
+                    ),
+                    ItineraryDayDto(
+                        id = "day-trim-2",
+                        tripId = tripId,
+                        date = "2026-06-11",
+                        dayNumber = 2,
+                        city = null,
+                        cityProviderId = null,
+                        cityLat = null,
+                        cityLon = null,
+                        isOutOfRange = true,
+                        activities = emptyList(),
+                    ),
+                )
+            )
+        }
+        val repository = ItineraryRepositoryImpl(
+            api = api,
+            syncQueueRepository = queue,
+            itineraryCacheStore = itineraryStore,
+            networkStateProvider = networkStateProvider,
+        )
+
+        // WHEN
+        repository.trimOutOfRange(
+            tripId = tripId,
+            request = TrimOutOfRangeRequest(
+                action = "remove",
+                dayIds = listOf("day-trim-2"),
+            )
+        )
+
+        // THEN
+        assertEquals(1, itineraryStore.getItinerary(tripId).size)
+        assertEquals("day-trim-1", itineraryStore.getItinerary(tripId).first().id)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.ITINERARY_TRIM, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals(tripId, pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_updateSettings_then_setsLocalSettingsAndQueuesUpsert() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.updateNotificationSettings(any()) } throws IOException("offline")
+        val settingsStore = FakeNotificationsCacheStore()
+        val networkProvider = mockk<NetworkStateProvider>()
+        every { networkProvider.isOnline() } returns true
+        val repository = NotificationRepositoryImpl(
+            api = api,
+            notificationsCacheStore = settingsStore,
+            syncQueueRepository = queue,
+            networkStateProvider = networkProvider,
+        )
+        val settings = listOf(NotificationSettingDto(key = "ideas_comments", enabled = false))
+
+        // WHEN
+        val result = repository.updateSettings(settings)
+
+        // THEN
+        assertTrue(result.isSuccess)
+        assertEquals(settings, settingsStore.getSettings())
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.NOTIFICATION_SETTINGS, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("me", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_updateMe_then_setsLocalUserAndQueuesProfileUpsert() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.updateMe(any()) } throws IOException("offline")
+        val userStore = FakeUserCacheStore().apply {
+            setUser(UserDto(id = "user-1", name = "Before Name", initials = "BN"))
+        }
+        val repository = UserRepositoryImpl(
+            api = api,
+            sessionCleaner = mockk<SessionCleaner>(relaxed = true),
+            userCacheStore = userStore,
+            pushTokenSyncManager = mockk<PushTokenSyncManager>(relaxed = true),
+            syncQueueRepository = queue,
+        )
+
+        // WHEN
+        val updated = repository.updateMe(
+            UpdateUserRequest(
+                name = "After Name",
+                photoUrl = "https://photo",
+            )
+        )
+
+        // THEN
+        assertEquals("user-1", updated.id)
+        assertEquals("After Name", updated.name)
+        assertEquals("After Name", userStore.getUser()?.name)
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.USER_PROFILE, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("me", pending.first().entityId)
+    }
+
+    @Test
+    fun given_apiOffline_when_saveAiSuggestion_then_queuesSaveCommand() = runTest {
+        // GIVEN
+        val api = mockk<CoTripApi>()
+        coEvery { api.saveAiSuggestionToIdeas(any()) } throws IOException("offline")
+        val repository = AiSuggestionsRepositoryImpl(
+            api = api,
+            syncQueueRepository = queue,
+        )
+
+        // WHEN
+        repository.saveSuggestionToIdeas("suggestion-1")
+
+        // THEN
+        val pending = database.syncChangeDao().listPending(10)
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.AI_SUGGESTION_SAVE, pending.first().entity)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("suggestion-1", pending.first().entityId)
     }
 
     private class NoOpSyncScheduler(context: Context) : SyncScheduler(context) {
@@ -459,5 +891,52 @@ private class FakeExpensesCacheStore : ExpensesCacheStore {
 
     override suspend fun clearAll() {
         byTrip.value = emptyMap()
+    }
+}
+
+private class FakeNotificationsCacheStore : NotificationsCacheStore {
+    private val notificationsState = MutableStateFlow<List<NotificationDto>>(emptyList())
+    private val settingsState = MutableStateFlow<List<NotificationSettingDto>>(emptyList())
+
+    override val notifications: Flow<List<NotificationDto>> = notificationsState
+    override val settings: Flow<List<NotificationSettingDto>> = settingsState
+
+    override suspend fun getNotifications(): List<NotificationDto> = notificationsState.value
+
+    override suspend fun getSettings(): List<NotificationSettingDto> = settingsState.value
+
+    override suspend fun setNotifications(items: List<NotificationDto>) {
+        notificationsState.value = items
+    }
+
+    override suspend fun markRead(notificationId: String) {
+        notificationsState.value = notificationsState.value.map { notification ->
+            if (notification.id == notificationId) {
+                notification.copy(readAt = "2026-01-01T00:00:00Z")
+            } else {
+                notification
+            }
+        }
+    }
+
+    override suspend fun markReadBulkNonComment() {
+        notificationsState.value = notificationsState.value.map {
+            it.copy(readAt = "2026-01-01T00:00:00Z")
+        }
+    }
+
+    override suspend fun markReadBulkIdeaComments(ideaId: String) {
+        notificationsState.value = notificationsState.value.map {
+            it.copy(readAt = "2026-01-01T00:00:00Z")
+        }
+    }
+
+    override suspend fun setSettings(items: List<NotificationSettingDto>) {
+        settingsState.value = items
+    }
+
+    override suspend fun clear() {
+        notificationsState.value = emptyList()
+        settingsState.value = emptyList()
     }
 }

--- a/android/app/src/test/java/nvk/cotrip/data/sync/SyncQueueRepositoryTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/data/sync/SyncQueueRepositoryTest.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import nvk.cotrip.data.network.dto.NotificationSettingDto
 import nvk.cotrip.data.network.dto.UpdateIdeaRequest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -81,6 +82,56 @@ class SyncQueueRepositoryTest {
         assertEquals(2, pending.size)
         assertEquals(listOf("create", "upsert"), pending.map { it.type })
         assertTrue(pending.all { it.entityId == "idea-2" })
+    }
+
+    @Test
+    fun given_twoUpsertsForSameEntityId_when_enqueueUpsert_then_onlyLatestIsKept() = runTest {
+        // GIVEN
+        queue.enqueueUpsert(
+            entity = SyncEntities.EXPENSE,
+            id = "expense-1",
+            payload = mapOf("title" to "first")
+        )
+        queue.enqueueUpsert(
+            entity = SyncEntities.EXPENSE,
+            id = "expense-1",
+            payload = mapOf("title" to "latest")
+        )
+
+        // WHEN
+        val pending = dao.listPending(limit = 50)
+
+        // THEN
+        assertEquals(1, pending.size)
+        assertEquals("upsert", pending.first().type)
+        assertEquals("expense-1", pending.first().entityId)
+    }
+
+    @Test
+    fun given_commandUpsertsForDifferentIds_when_enqueueUpsert_then_keepsSingleLatestItem() = runTest {
+        // GIVEN
+        queue.enqueueUpsert(
+            entity = SyncEntities.NOTIFICATION_SETTINGS,
+            id = "settings-1",
+            payload = SyncNotificationSettingsUpsertPayload(
+                items = listOf(NotificationSettingDto(key = "a", enabled = true))
+            )
+        )
+        queue.enqueueUpsert(
+            entity = SyncEntities.NOTIFICATION_SETTINGS,
+            id = "settings-2",
+            payload = SyncNotificationSettingsUpsertPayload(
+                items = listOf(NotificationSettingDto(key = "b", enabled = false))
+            )
+        )
+
+        // WHEN
+        val pending = dao.listPending(limit = 50)
+
+        // THEN
+        assertEquals(1, pending.size)
+        assertEquals(SyncEntities.NOTIFICATION_SETTINGS, pending.first().entity)
+        assertEquals("settings-2", pending.first().entityId)
     }
 
     private class NoOpSyncScheduler(context: Context) : SyncScheduler(context) {

--- a/android/app/src/test/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsViewModelTest.kt
@@ -5,15 +5,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.testing.MainDispatcherRule
@@ -120,7 +115,7 @@ class RouteSuggestionsViewModelTest {
     }
 
     @Test
-    fun given_unsavedSuggestion_when_onSaveClickSuccess_then_updatesStateAndEmitsToast() = runTest {
+    fun given_unsavedSuggestion_when_onSaveClickSuccess_then_updatesState() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val aiRepository = FakeAiSuggestionsRepository(
@@ -134,19 +129,12 @@ class RouteSuggestionsViewModelTest {
             city = "Rome",
         )
         advanceUntilIdle()
-        val effects = mutableListOf<RouteSuggestionsEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
 
         // WHEN
         viewModel.onEvent(RouteSuggestionsEvent.OnSaveClick("s1"))
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(1, effects.size)
-        assertEquals(RouteSuggestionsEffect.ShowToastRes(R.string.ai_suggestions_saved), effects.single())
         assertEquals(1, aiRepository.saveSuggestionToIdeasCalls.size)
         assertEquals("s1", aiRepository.saveSuggestionToIdeasCalls.single())
         val content = viewModel.state.value as RouteSuggestionsState.Content

--- a/android/app/src/test/java/nvk/cotrip/ui/expense/form/CreateExpenseViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/expense/form/CreateExpenseViewModelTest.kt
@@ -1,9 +1,7 @@
 package nvk.cotrip.ui.expense.form
 
 import android.app.Application
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineStart
@@ -197,42 +195,31 @@ class CreateExpenseViewModelTest {
         viewModel.onEvent(ExpenseFormEvent.OnTitleChange("Lunch"))
         viewModel.onEvent(ExpenseFormEvent.OnAmountChange("25.50"))
         viewModel.onEvent(ExpenseFormEvent.OnPaidBySelected("user-1"))
-        val effects = mutableListOf<ExpenseFormEffect>()
-        val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(ExpenseFormEvent.OnPrimaryClick)
         advanceUntilIdle()
-        collectJob.join()
 
         // THEN
         assertEquals(1, expenseRepository.createExpenseCalls.size)
         assertEquals("trip-1", expenseRepository.createExpenseCalls.single().first)
         assertEquals("Lunch", expenseRepository.createExpenseCalls.single().second.title.trim())
         assertEquals(25.50, expenseRepository.createExpenseCalls.single().second.amount, 0.001)
-        assertEquals(R.string.expense_form_created_toast, (effects.single() as ExpenseFormEffect.ShowToastRes).resId)
         assertEquals(1, navigator.popCalls)
     }
 
     @Test
-    fun given_createScreen_when_onDeleteClick_then_emitsDeleteNotAvailableToast() = runTest {
+    fun given_createScreen_when_onDeleteClick_then_doesNotEmitEffect() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val viewModel = createViewModel()
         advanceUntilIdle()
-        val effects = mutableListOf<ExpenseFormEffect>()
-        val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
 
         // WHEN
         viewModel.onEvent(ExpenseFormEvent.OnDeleteClick)
         advanceUntilIdle()
-        collectJob.join()
 
         // THEN
-        assertEquals(R.string.expense_form_delete_not_available, (effects.single() as ExpenseFormEffect.ShowToastRes).resId)
+        assertTrue(!viewModel.state.value.isSaving)
     }
 
     @Test
@@ -471,7 +458,7 @@ class CreateExpenseViewModelTest {
     }
 
     @Test
-    fun given_limitDialogShown_when_deleteOldestAndRetrySuccess_then_emitsToastAndPopsBack() = runTest {
+    fun given_limitDialogShown_when_deleteOldestAndRetrySuccess_then_popsBack() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val limitReachedJson = """
@@ -498,19 +485,13 @@ class CreateExpenseViewModelTest {
         advanceUntilIdle()
 
         expenseRepository.createExpenseToThrow = null
-        val effects = mutableListOf<ExpenseFormEffect>()
-        val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(ExpenseFormEvent.OnConfirmDeleteOldestAndRetry)
         advanceUntilIdle()
-        collectJob.join()
 
         // THEN
         assertEquals(1, expenseRepository.deleteExpenseCalls.size)
         assertEquals("exp-old", expenseRepository.deleteExpenseCalls.single())
-        assertEquals(R.string.expense_form_created_toast, (effects.single() as ExpenseFormEffect.ShowToastRes).resId)
         assertEquals(1, navigator.popCalls)
     }
 
@@ -526,7 +507,6 @@ class CreateExpenseViewModelTest {
         expenseRepository: ExpenseFormFakeExpenseRepository = ExpenseFormFakeExpenseRepository(),
         userRepository: ExpenseFormFakeUserRepository = ExpenseFormFakeUserRepository(initialMe = expenseFormUserDto(id = "user-1")),
     ): CreateExpenseViewModel {
-        val appContext: Context = ApplicationProvider.getApplicationContext()
         return CreateExpenseViewModel(
             savedStateHandle = SavedStateHandle(
                 mapOf(Destination.CreateExpense.ARG_TRIP_ID to "trip-1")

--- a/android/app/src/test/java/nvk/cotrip/ui/expense/form/EditExpenseViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/expense/form/EditExpenseViewModelTest.kt
@@ -1,9 +1,7 @@
 package nvk.cotrip.ui.expense.form
 
 import android.app.Application
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineStart
@@ -142,7 +140,7 @@ class EditExpenseViewModelTest {
     }
 
     @Test
-    fun given_validData_when_onPrimaryClick_then_callsUpdateAndEitherPopsOrShowsToast() = runTest {
+    fun given_validData_when_onPrimaryClick_then_callsUpdateAndPopsBack() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val navigator = ExpenseFormFakeNavigator()
@@ -157,26 +155,17 @@ class EditExpenseViewModelTest {
 
         viewModel.onEvent(ExpenseFormEvent.OnTitleChange("Updated Lunch"))
         viewModel.onEvent(ExpenseFormEvent.OnAmountChange("35"))
+        viewModel.onEvent(ExpenseFormEvent.OnParticipantChecked("user-1", true))
+        viewModel.onEvent(ExpenseFormEvent.OnParticipantChecked("user-2", true))
         viewModel.onEvent(ExpenseFormEvent.OnPaidBySelected("user-2"))
-        val effects = mutableListOf<ExpenseFormEffect>()
-        val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(ExpenseFormEvent.OnPrimaryClick)
         advanceUntilIdle()
         advanceUntilIdle()
-        collectJob.join()
 
         // THEN
-        assertTrue(
-            "Expected either navigation back (success) or an effect (toast)",
-            navigator.popCalls == 1 || effects.isNotEmpty()
-        )
-        if (effects.isNotEmpty()) {
-            assertTrue((effects.single() as ExpenseFormEffect.ShowToastRes).resId == R.string.expense_form_saved_toast ||
-                (effects.single() as ExpenseFormEffect.ShowToastRes).resId == R.string.common_error_message)
-        }
+        assertEquals(1, expenseRepository.updateExpenseCalls.size)
+        assertEquals(1, navigator.popCalls)
     }
 
     @Test
@@ -193,19 +182,13 @@ class EditExpenseViewModelTest {
         )
         advanceUntilIdle()
 
-        val effects = mutableListOf<ExpenseFormEffect>()
-        val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(ExpenseFormEvent.OnDeleteClick)
         advanceUntilIdle()
-        collectJob.join()
 
         // THEN
         assertEquals(1, expenseRepository.deleteExpenseCalls.size)
         assertEquals("exp-1", expenseRepository.deleteExpenseCalls.single())
-        assertEquals(R.string.expense_form_deleted_toast, (effects.single() as ExpenseFormEffect.ShowToastRes).resId)
         assertEquals(1, navigator.popCalls)
     }
 
@@ -328,7 +311,6 @@ class EditExpenseViewModelTest {
             ),
         ),
     ): EditExpenseViewModel {
-        val appContext: Context = ApplicationProvider.getApplicationContext()
         return EditExpenseViewModel(
             savedStateHandle = SavedStateHandle(
                 mapOf(

--- a/android/app/src/test/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModelTest.kt
@@ -8,13 +8,9 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import nvk.cotrip.R
 import nvk.cotrip.data.auth.SessionStore
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.NetworkStateProvider
@@ -186,21 +182,16 @@ class IdeaDetailsViewModelTest {
         )
         advanceUntilIdle()
 
-        val effects = mutableListOf<IdeaDetailsEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
         // WHEN
         viewModel.onEvent(IdeaDetailsEvent.OnDeleteClick)
         advanceUntilIdle()
 
         // THEN
-        assertTrue(effects.any { it is IdeaDetailsEffect.ShowToastRes })
-        assertEquals(R.string.idea_details_deleted_toast, (effects.single() as IdeaDetailsEffect.ShowToastRes).resId)
         assertEquals(1, navigator.popCalls)
     }
 
     @Test
-    fun given_ideaLoaded_when_onApproveClickSuccess_then_updatesStatusAndShowsToast() = runTest {
+    fun given_ideaLoaded_when_onApproveClickSuccess_then_updatesStatus() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val idea = ideaDto(id = ideaId, tripId = tripId, status = "suggested")
@@ -208,42 +199,32 @@ class IdeaDetailsViewModelTest {
         val viewModel = createViewModel(ideaRepository = ideaRepo)
         advanceUntilIdle()
 
-        val effects = mutableListOf<IdeaDetailsEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
         // WHEN
         viewModel.onEvent(IdeaDetailsEvent.OnApproveClick)
         advanceUntilIdle()
 
         // THEN
         assertEquals("approved", viewModel.state.value.status)
-        assertTrue(effects.any { it is IdeaDetailsEffect.ShowToastRes })
-        assertEquals(R.string.idea_details_approved_toast, (effects.single() as IdeaDetailsEffect.ShowToastRes).resId)
     }
 
     @Test
-    fun given_ideaLoaded_when_onRejectClickSuccess_then_updatesStatusAndShowsToast() = runTest {
+    fun given_ideaLoaded_when_onRejectClickSuccess_then_updatesStatus() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val idea = ideaDto(id = ideaId, tripId = tripId, status = "suggested")
         val viewModel = createViewModel(ideaRepository = FakeIdeaRepository(initialIdea = idea))
         advanceUntilIdle()
 
-        val effects = mutableListOf<IdeaDetailsEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
         // WHEN
         viewModel.onEvent(IdeaDetailsEvent.OnRejectClick)
         advanceUntilIdle()
 
         // THEN
         assertEquals("rejected", viewModel.state.value.status)
-        assertTrue(effects.any { it is IdeaDetailsEffect.ShowToastRes })
-        assertEquals(R.string.idea_details_rejected_toast, (effects.single() as IdeaDetailsEffect.ShowToastRes).resId)
     }
 
     @Test
-    fun given_dayPickerOpen_when_onDaySelected_then_convertsIdeaToActivityAndShowsToast() = runTest {
+    fun given_dayPickerOpen_when_onDaySelected_then_convertsIdeaToActivity() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val start = LocalDate.now()
@@ -263,9 +244,6 @@ class IdeaDetailsViewModelTest {
         advanceUntilIdle()
         val dayOption = viewModel.state.value.dayPicker!!.days.single()
 
-        val effects = mutableListOf<IdeaDetailsEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
         // WHEN
         viewModel.onEvent(IdeaDetailsEvent.OnDaySelected(dayOption))
         advanceUntilIdle()
@@ -274,8 +252,6 @@ class IdeaDetailsViewModelTest {
         assertEquals(1, ideaRepo.convertIdeaToActivityCalls.size)
         assertEquals(ideaId, ideaRepo.convertIdeaToActivityCalls.single().first)
         assertEquals("day-1", ideaRepo.convertIdeaToActivityCalls.single().second.dayId)
-        assertTrue(effects.any { it is IdeaDetailsEffect.ShowToastRes })
-        assertEquals(R.string.idea_details_added_toast, (effects.single() as IdeaDetailsEffect.ShowToastRes).resId)
     }
 
     private fun createViewModel(

--- a/android/app/src/test/java/nvk/cotrip/ui/idea/list/TripIdeasViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/idea/list/TripIdeasViewModelTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import nvk.cotrip.R
 import nvk.cotrip.data.auth.SessionStore
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.NetworkStateProvider
@@ -223,7 +222,7 @@ class TripIdeasViewModelTest {
     }
 
     @Test
-    fun given_dayPickerOpen_when_onDaySelectedSuccess_then_emitsToast() = runTest {
+    fun given_dayPickerOpen_when_onDaySelectedSuccess_then_updatesIdeaUi() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val start = LocalDate.now()
@@ -243,16 +242,13 @@ class TripIdeasViewModelTest {
 
         val state = viewModel.state.value as TripIdeasState.Content
         val dayOption = state.dayPicker!!.days.single()
-        val effects = mutableListOf<TripIdeasEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
         // WHEN
         viewModel.onEvent(TripIdeasEvent.OnDaySelected(dayOption))
         advanceUntilIdle()
 
         // THEN
-        assertTrue(effects.any { it is TripIdeasEffect.ShowToastRes })
-        assertEquals(R.string.ideas_added_to_itinerary_toast, (effects.single() as TripIdeasEffect.ShowToastRes).resId)
+        val updated = viewModel.state.value as TripIdeasState.Content
+        assertEquals(1, updated.ideas.single().addedDay)
     }
 
     private fun createViewModel(

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleViewModelTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -15,7 +15,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.data.network.dto.InviteInfoDto
@@ -101,7 +100,7 @@ class InvitePeopleViewModelTest {
     }
 
     @Test
-    fun given_contentShown_when_onCopyClick_then_emitsCopyAndToastEffects() = runTest {
+    fun given_contentShown_when_onCopyClick_then_emitsCopyEffect() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val viewModel = createViewModel(
@@ -113,7 +112,7 @@ class InvitePeopleViewModelTest {
 
         val collected = mutableListOf<InvitePeopleEffect>()
         val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(2).toList(collected)
+            viewModel.effects.take(1).toList(collected)
         }
 
         // WHEN
@@ -123,10 +122,7 @@ class InvitePeopleViewModelTest {
 
         // THEN
         assertEquals(
-            listOf(
-                InvitePeopleEffect.CopyToClipboard("https://api.cotrip.site/invite/token"),
-                InvitePeopleEffect.ShowToastRes(R.string.invite_people_copied_toast),
-            ),
+            listOf(InvitePeopleEffect.CopyToClipboard("https://api.cotrip.site/invite/token")),
             collected,
         )
     }

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripViewModelTest.kt
@@ -79,7 +79,7 @@ class JoinTripViewModelTest {
     }
 
     @Test
-    fun given_invalidInput_when_joinClick_then_showsValidationToast() = runTest {
+    fun given_invalidInput_when_joinClick_then_setsInlineValidationError() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val viewModel = createViewModel(
@@ -87,25 +87,18 @@ class JoinTripViewModelTest {
             tripRepository = FakeTripRepository(),
             navigator = FakeNavigator(),
         )
-        val collected = mutableListOf<JoinTripEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(collected)
-        }
-
         // WHEN
         viewModel.onEvent(JoinTripEvent.OnInviteInputChange("invalid"))
         viewModel.onEvent(JoinTripEvent.OnJoinClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        val effect = collected.single()
-        assertEquals(JoinTripEffect.ShowToastRes(R.string.join_trip_invalid), effect)
+        assertEquals(R.string.join_trip_invalid, viewModel.state.value.inlineErrorRes)
         assertFalse(viewModel.state.value.isLoading)
     }
 
     @Test
-    fun given_validToken_when_joinByTokenSuccess_then_navigatesAndResetsLoading() = runTest {
+    fun given_validToken_when_joinByTokenSuccess_then_navigatesAndResetsLoadingWithoutToast() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val token = "b".repeat(32)
@@ -116,26 +109,20 @@ class JoinTripViewModelTest {
         val tripRepository = FakeTripRepository()
         val navigator = FakeNavigator()
         val viewModel = createViewModel(inviteRepository, tripRepository, navigator)
-        val collected = mutableListOf<JoinTripEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(collected)
-        }
 
         // WHEN
         viewModel.onEvent(JoinTripEvent.OnInviteInputChange(token))
         viewModel.onEvent(JoinTripEvent.OnJoinClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(JoinTripEffect.ShowToastRes(R.string.join_trip_success), collected.single())
         assertEquals(Destination.TripDetails("trip-1"), navigator.lastDestination)
         assertFalse(viewModel.state.value.isLoading)
         assertEquals(listOf(token), inviteRepository.acceptCalls)
     }
 
     @Test
-    fun given_alreadyMember_when_joinByToken_then_showsAlreadyJoinedToast() = runTest {
+    fun given_alreadyMember_when_joinByToken_then_setsInlineError() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val token = "c".repeat(32)
@@ -146,22 +133,14 @@ class JoinTripViewModelTest {
             trips = MutableStateFlow(listOf(trip("joined-trip")))
         )
         val viewModel = createViewModel(inviteRepository, tripRepository, FakeNavigator())
-        val collected = mutableListOf<JoinTripEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(collected)
-        }
 
         // WHEN
         viewModel.onEvent(JoinTripEvent.OnInviteInputChange(token))
         viewModel.onEvent(JoinTripEvent.OnJoinClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(
-            JoinTripEffect.ShowToastRes(R.string.join_trip_already_joined),
-            collected.single(),
-        )
+        assertEquals(R.string.join_trip_already_joined, viewModel.state.value.inlineErrorRes)
         assertTrue(inviteRepository.acceptCalls.isEmpty())
         assertFalse(viewModel.state.value.isLoading)
     }
@@ -200,7 +179,7 @@ class JoinTripViewModelTest {
     }
 
     @Test
-    fun given_joinByTripIdWithBlankServerResponse_when_joinClick_then_fallsBackToInputTripId() = runTest {
+    fun given_joinByTripIdWithBlankServerResponse_when_joinClick_then_fallsBackToInputTripIdAndNavigates() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val tripId = "550e8400-e29b-41d4-a716-446655440000"
@@ -213,19 +192,13 @@ class JoinTripViewModelTest {
             tripRepository = FakeTripRepository(),
             navigator = navigator,
         )
-        val collected = mutableListOf<JoinTripEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(collected)
-        }
 
         // WHEN
         viewModel.onEvent(JoinTripEvent.OnInviteInputChange(tripId))
         viewModel.onEvent(JoinTripEvent.OnJoinClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(JoinTripEffect.ShowToastRes(R.string.join_trip_success), collected.single())
         assertEquals(Destination.TripDetails(tripId), navigator.lastDestination)
         assertEquals(listOf(tripId), inviteRepository.joinByIdCalls)
     }

--- a/android/app/src/test/java/nvk/cotrip/ui/itinerary/TripItineraryViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/itinerary/TripItineraryViewModelTest.kt
@@ -96,7 +96,7 @@ class TripItineraryViewModelTest {
     }
 
     @Test
-    fun given_pendingCities_when_completeRequiredSelection_then_emitsToastAndStays() = runTest {
+    fun given_pendingCities_when_completeRequiredSelection_then_setsInlineErrorAndStays() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val today = LocalDate.now()
@@ -125,20 +125,12 @@ class TripItineraryViewModelTest {
         )
         advanceUntilIdle()
 
-        val effects = mutableListOf<TripItineraryEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(TripItineraryEvent.OnCompleteRequiredCitySelection)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(
-            TripItineraryEffect.ShowToastRes(R.string.itinerary_city_setup_required_toast),
-            effects.single(),
-        )
+        assertEquals(R.string.itinerary_city_setup_required_toast, viewModel.state.value.inlineErrorRes)
         assertTrue(navigator.destinations.isEmpty())
     }
 

--- a/android/app/src/test/java/nvk/cotrip/ui/outofrangedays/OutOfRangeDaysViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/outofrangedays/OutOfRangeDaysViewModelTest.kt
@@ -105,7 +105,7 @@ class OutOfRangeDaysViewModelTest {
     }
 
     @Test
-    fun given_contentShown_when_extendEndClick_then_trimsAndEmitsToastAndPops() = runTest {
+    fun given_contentShown_when_extendEndClick_then_trimsAndPops() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val navigator = FakeNavigator()
@@ -121,24 +121,14 @@ class OutOfRangeDaysViewModelTest {
         )
         advanceUntilIdle()
 
-        val collected = mutableListOf<OutOfRangeDaysEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(collected)
-        }
-
         // WHEN
         viewModel.onEvent(OutOfRangeDaysEvent.OnExtendEndClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
         assertEquals(1, itineraryRepository.trimCalls.size)
         assertEquals("extend_end", itineraryRepository.trimCalls.single().action)
         assertEquals(listOf("day-3"), itineraryRepository.trimCalls.single().dayIds)
-        assertEquals(
-            OutOfRangeDaysEffect.ShowToastRes(R.string.out_of_range_days_extended_toast),
-            collected.single(),
-        )
         assertEquals(1, navigator.popCalls)
     }
 

--- a/android/app/src/test/java/nvk/cotrip/ui/settings/SettingsViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/settings/SettingsViewModelTest.kt
@@ -130,7 +130,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun given_photoPicked_when_uploadSuccess_then_updatesPhotoAndEmitsToast() = runTest {
+    fun given_photoPicked_when_uploadSuccess_then_updatesPhoto() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val imageUploadRepository = SettingsFakeImageUploadRepository().apply {
@@ -143,21 +143,15 @@ class SettingsViewModelTest {
         )
         advanceUntilIdle()
 
-        val effects = mutableListOf<SettingsEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
         // WHEN
         viewModel.onEvent(SettingsEvent.OnPhotoPicked("content://photo/1"))
         advanceUntilIdle()
-        collector.join()
 
         // THEN
         val profile = viewModel.state.value.profile
         assertTrue(profile.hasPhoto)
         assertEquals("https://cdn.example/new-avatar.jpg", profile.photoUrl)
         assertTrue(viewModel.state.value.canSave)
-        assertEquals(SettingsEffect.ShowToastRes(R.string.settings_photo_changed_toast), effects.single())
     }
 
     @Test
@@ -173,23 +167,16 @@ class SettingsViewModelTest {
         )
         advanceUntilIdle()
 
-        val effects = mutableListOf<SettingsEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
-
         // WHEN
         viewModel.onEvent(SettingsEvent.OnDeleteProfileClick)
         assertTrue(viewModel.state.value.showDeleteDialog)
         viewModel.onEvent(SettingsEvent.OnConfirmDeleteProfileClick)
         advanceUntilIdle()
-        collector.join()
 
         // THEN
         assertEquals(1, userRepository.deleteCalls)
         assertEquals(1, userRepository.clearSessionCalls)
         assertTrue(navigator.destinations.contains(Destination.SignIn))
-        assertEquals(SettingsEffect.ShowToastRes(R.string.settings_profile_deleted_toast), effects.single())
         assertFalse(viewModel.state.value.showDeleteDialog)
     }
 

--- a/android/app/src/test/java/nvk/cotrip/ui/trip/form/CreateTripViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/trip/form/CreateTripViewModelTest.kt
@@ -5,9 +5,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -98,32 +95,25 @@ class CreateTripViewModelTest {
     }
 
     @Test
-    fun given_invalidStartDate_when_onStartDateSelected_then_emitsToast() = runTest {
+    fun given_invalidStartDate_when_onStartDateSelected_then_setsStartDateInlineError() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val viewModel = createViewModel()
-        val effects = mutableListOf<TripFormEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
 
         // WHEN
         viewModel.onEvent(TripFormEvent.OnStartDateSelected(LocalDate.now().minusDays(1)))
         advanceUntilIdle()
 
         // THEN
-        assertTrue(effects.isNotEmpty())
-        assertTrue(effects.any { it is TripFormEffect.ShowToastRes && it.resId == R.string.trip_form_start_date_range_toast })
+        assertEquals(R.string.trip_form_start_date_range_toast, viewModel.state.value.startDateErrorRes)
     }
 
     @Test
-    fun given_invalidEndDate_when_onEndDateSelected_then_emitsToast() = runTest {
+    fun given_invalidEndDate_when_onEndDateSelected_then_setsEndDateInlineError() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val viewModel = createViewModel()
         viewModel.onEvent(TripFormEvent.OnStartDateSelected(LocalDate.now()))
-        advanceUntilIdle()
-        val effects = mutableListOf<TripFormEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
         advanceUntilIdle()
 
         // WHEN
@@ -131,8 +121,7 @@ class CreateTripViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        assertTrue(effects.isNotEmpty())
-        assertTrue(effects.any { it is TripFormEffect.ShowToastRes && it.resId == R.string.trip_form_end_date_range_toast })
+        assertEquals(R.string.trip_form_end_date_range_toast, viewModel.state.value.endDateErrorRes)
     }
 
     @Test
@@ -153,9 +142,6 @@ class CreateTripViewModelTest {
         viewModel.onEvent(TripFormEvent.OnEndDateSelected(LocalDate.now().plusDays(1)))
         advanceUntilIdle()
         assertTrue(viewModel.state.value.canSubmit)
-        val effects = mutableListOf<TripFormEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
 
         // WHEN
         viewModel.onEvent(TripFormEvent.OnPrimaryActionClick)
@@ -164,7 +150,6 @@ class CreateTripViewModelTest {
         // THEN
         assertTrue("Expected navigate to TripItinerary, got: ${navigator.destinations}", navigator.destinations.isNotEmpty())
         assertTrue(navigator.destinations.any { it is nvk.cotrip.ui.navigation.Destination.TripItinerary })
-        assertTrue(effects.any { it is TripFormEffect.ShowToastRes })
     }
 
     @Test

--- a/android/app/src/test/java/nvk/cotrip/ui/trip/form/EditTripViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/trip/form/EditTripViewModelTest.kt
@@ -5,13 +5,9 @@ import androidx.lifecycle.SavedStateHandle
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.testing.MainDispatcherRule
@@ -84,7 +80,7 @@ class EditTripViewModelTest {
     }
 
     @Test
-    fun given_validData_when_onPrimaryActionClick_then_callsUpdateTripAndShowsToast() = runTest {
+    fun given_validData_when_onPrimaryActionClick_then_callsUpdateTripAndCloses() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val start = LocalDate.now()
@@ -101,21 +97,17 @@ class EditTripViewModelTest {
         advanceUntilIdle()
         viewModel.onEvent(TripFormEvent.OnNameChange("Updated Title"))
         advanceUntilIdle()
-        val effects = mutableListOf<TripFormEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
 
         // WHEN
         viewModel.onEvent(TripFormEvent.OnPrimaryActionClick)
         advanceUntilIdle()
 
         // THEN
-        assertTrue(effects.any { it is TripFormEffect.ShowToastRes && it.resId == R.string.edit_trip_saved_toast })
         assertTrue(navigator.popCalls >= 1)
     }
 
     @Test
-    fun given_tripLoaded_when_onArchiveClickSuccess_then_showsToastAndCloses() = runTest {
+    fun given_tripLoaded_when_onArchiveClickSuccess_then_closes() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val trip = tripDetailsTripDto(
@@ -132,9 +124,6 @@ class EditTripViewModelTest {
             navigator = navigator,
         )
         advanceUntilIdle()
-        val effects = mutableListOf<TripFormEffect>()
-        launch { viewModel.effects.take(1).toList(effects) }
-        advanceUntilIdle()
 
         // WHEN
         viewModel.onEvent(TripFormEvent.OnArchiveClick)
@@ -142,7 +131,6 @@ class EditTripViewModelTest {
 
         // THEN
         assertEquals(1, navigator.popCalls)
-        assertTrue(effects.any { it is TripFormEffect.ShowToastRes && it.resId == R.string.edit_trip_archived_toast })
     }
 
     @Test

--- a/android/app/src/test/java/nvk/cotrip/ui/trip/members/TripMembersViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/trip/members/TripMembersViewModelTest.kt
@@ -177,7 +177,7 @@ class TripMembersViewModelTest {
     }
 
     @Test
-    fun given_otherMember_when_onRemoveClickSuccess_then_emitsToastAndDoesNotNavigate() = runTest {
+    fun given_otherMember_when_onRemoveClickSuccess_then_doesNotNavigate() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val navigator = TripDetailsFakeNavigator()
@@ -200,24 +200,16 @@ class TripMembersViewModelTest {
             tripId = "trip-1",
         )
         advanceUntilIdle()
-        val effects = mutableListOf<TripMembersEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
-
         // WHEN
         viewModel.onEvent(TripMembersEvent.OnRemoveClick("guest-1"))
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(1, effects.size)
-        assertTrue(effects.single() is TripMembersEffect.ShowToastRes)
         assertEquals(0, navigator.destinations.size)
     }
 
     @Test
-    fun given_selfMember_when_onRemoveClickSuccess_then_navigatesToTripsAndEmitsToast() = runTest {
+    fun given_selfMember_when_onRemoveClickSuccess_then_navigatesToTrips() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val navigator = TripDetailsFakeNavigator()
@@ -237,18 +229,11 @@ class TripMembersViewModelTest {
             tripId = "trip-1",
         )
         advanceUntilIdle()
-        val effects = mutableListOf<TripMembersEffect>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            viewModel.effects.take(1).toList(effects)
-        }
-
         // WHEN
         viewModel.onEvent(TripMembersEvent.OnRemoveClick("owner-1"))
         advanceUntilIdle()
-        collector.join()
 
         // THEN
-        assertEquals(1, effects.size)
         assertTrue(navigator.destinations.any { it is Destination.Trips })
     }
 

--- a/backend/src/main/kotlin/nvk/cotrip/backend/db/ActivityRepository.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/db/ActivityRepository.kt
@@ -197,6 +197,24 @@ object ActivityRepository {
         }
     }
 
+    fun findBySourceIdea(dayId: String, sourceIdeaId: String): ActivityRow? = dbQuery { conn ->
+        conn.prepareStatement(
+            """
+            SELECT id, day_id, source_idea_id, title, time_text, location_name, link, cost_amount, cost_type, notes, order_index, created_at
+            FROM activities
+            WHERE day_id = ? AND source_idea_id = ? AND deleted_at IS NULL
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """.trimIndent()
+        ).use { stmt ->
+            stmt.setObject(1, UUID.fromString(dayId))
+            stmt.setObject(2, UUID.fromString(sourceIdeaId))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) mapActivity(rs) else null
+            }
+        }
+    }
+
     fun update(
         activityId: String,
         title: String?,

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutes.kt
@@ -882,16 +882,16 @@ private fun applyTripMemberDelete(userId: String, item: SyncPushItem) {
 
 private fun applyIdeaStatusUpsert(userId: String, item: SyncPushItem) {
     val ideaId = normalizeUuid(item.id)
-    val existing = IdeaRepository.get(ideaId)
-        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
-    if (!TripRepository.isOwner(existing.tripId, userId)) {
-        throw SyncApplyException(REASON_FORBIDDEN)
-    }
-
     val payload = decodePayload<SyncIdeaStatusUpsertPayload>(item.payload)
     val status = payload.status.trim().lowercase()
     if (status != "approved" && status != "rejected") {
         throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    }
+
+    val existing = IdeaRepository.get(ideaId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (!TripRepository.isOwner(existing.tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
     }
     if (existing.status == status) {
         return

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutes.kt
@@ -17,16 +17,20 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import nvk.cotrip.backend.db.ActivityRepository
+import nvk.cotrip.backend.db.AiRepository
 import nvk.cotrip.backend.db.DayRepository
 import nvk.cotrip.backend.db.ExpenseParticipantRow
 import nvk.cotrip.backend.db.ExpenseRepository
 import nvk.cotrip.backend.db.IdeaRepository
 import nvk.cotrip.backend.db.ItineraryDayRepository
+import nvk.cotrip.backend.db.NotificationRepository
+import nvk.cotrip.backend.db.NotificationSettingRow
 import nvk.cotrip.backend.db.SyncRepository
 import nvk.cotrip.backend.db.TripMemberRepository
 import nvk.cotrip.backend.db.TripDaySeed
 import nvk.cotrip.backend.db.TripRepository
 import nvk.cotrip.backend.db.TripUpdate
+import nvk.cotrip.backend.db.UserRepository
 import nvk.cotrip.backend.limits.LimitReachedException
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -135,6 +139,60 @@ private data class SyncActivityCreatePayload(
     val orderIndex: Int? = null,
 )
 
+@Serializable
+private data class SyncTripMemberDeletePayload(
+    val tripId: String,
+    val memberId: String,
+)
+
+@Serializable
+private data class SyncIdeaStatusUpsertPayload(
+    val status: String,
+)
+
+@Serializable
+private data class SyncIdeaConvertCreatePayload(
+    val dayId: String,
+    val timeText: String? = null,
+    val orderIndex: Int? = null,
+)
+
+@Serializable
+private data class SyncActivityReorderUpsertPayload(
+    val dayId: String,
+    val orderedIds: List<String> = emptyList(),
+)
+
+@Serializable
+private data class SyncItineraryTrimUpsertPayload(
+    val tripId: String,
+    val action: String,
+    val dayIds: List<String>,
+)
+
+@Serializable
+private data class SyncNotificationSettingsUpsertPayload(
+    val items: List<NotificationSettingDto> = emptyList(),
+)
+
+@Serializable
+private data class SyncNotificationReadUpsertPayload(
+    val mode: String,
+    val notificationId: String? = null,
+    val ideaId: String? = null,
+)
+
+@Serializable
+private data class SyncUserProfileUpsertPayload(
+    val name: String,
+    val photoUrl: String? = null,
+)
+
+@Serializable
+private data class SyncAiSuggestionSaveUpsertPayload(
+    val suggestionId: String? = null,
+)
+
 private const val OP_UPSERT = "upsert"
 private const val OP_DELETE = "delete"
 private const val OP_CREATE = "create"
@@ -147,6 +205,9 @@ private const val REASON_DEPENDENCY_NOT_READY = "dependency_not_ready"
 private const val REASON_UNSUPPORTED_OPERATION = "unsupported_operation"
 private const val REASON_UNSUPPORTED_ENTITY = "unsupported_entity"
 private const val REASON_INTERNAL_ERROR = "internal_error"
+
+private const val READ_BULK_MODE_NON_COMMENT = "non_comment"
+private const val READ_BULK_MODE_IDEA_COMMENTS = "idea_comments"
 
 private val syncJson = Json { ignoreUnknownKeys = true }
 
@@ -275,6 +336,7 @@ private fun applyCreate(userId: String, item: SyncPushItem) {
         "idea" -> applyIdeaCreate(userId = userId, item = item)
         "activity" -> applyActivityCreate(userId = userId, item = item)
         "expense" -> applyExpenseCreate(userId = userId, item = item)
+        "idea_convert" -> applyIdeaConvertCreate(userId = userId, item = item)
         "itinerary_day" -> throw SyncApplyException(REASON_UNSUPPORTED_OPERATION)
         else -> throw SyncApplyException(REASON_UNSUPPORTED_ENTITY)
     }
@@ -287,6 +349,13 @@ private fun applyUpsert(userId: String, item: SyncPushItem) {
         "itinerary_day" -> applyDayUpsert(userId = userId, item = item)
         "activity" -> applyActivityUpsert(userId = userId, item = item)
         "expense" -> applyExpenseUpsert(userId = userId, item = item)
+        "idea_status" -> applyIdeaStatusUpsert(userId = userId, item = item)
+        "activity_reorder" -> applyActivityReorderUpsert(userId = userId, item = item)
+        "itinerary_trim" -> applyItineraryTrimUpsert(userId = userId, item = item)
+        "notification_settings" -> applyNotificationSettingsUpsert(userId = userId, item = item)
+        "notification_read" -> applyNotificationReadUpsert(userId = userId, item = item)
+        "user_profile" -> applyUserProfileUpsert(userId = userId, item = item)
+        "ai_suggestion_save" -> applyAiSuggestionSaveUpsert(userId = userId, item = item)
         else -> throw SyncApplyException(REASON_UNSUPPORTED_ENTITY)
     }
 }
@@ -297,6 +366,7 @@ private fun applyDelete(userId: String, item: SyncPushItem) {
         "idea" -> applyIdeaDelete(userId = userId, item = item)
         "activity" -> applyActivityDelete(userId = userId, item = item)
         "expense" -> applyExpenseDelete(userId = userId, item = item)
+        "trip_member" -> applyTripMemberDelete(userId = userId, item = item)
         "itinerary_day" -> throw SyncApplyException(REASON_UNSUPPORTED_OPERATION)
         else -> throw SyncApplyException(REASON_UNSUPPORTED_ENTITY)
     }
@@ -783,6 +853,215 @@ private fun applyExpenseDelete(userId: String, item: SyncPushItem) {
     if (!deleted) {
         throw SyncApplyException(REASON_NOT_FOUND)
     }
+}
+
+private fun applyTripMemberDelete(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncTripMemberDeletePayload>(item.payload)
+    val tripId = normalizeUuid(payload.tripId)
+    val memberId = normalizeUuid(payload.memberId)
+
+    if (!TripRepository.isMember(tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val target = TripMemberRepository.findMember(tripId, memberId) ?: return
+    if (target.role == "owner") {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val isOwner = TripRepository.isOwner(tripId, userId)
+    if (!isOwner && userId != memberId) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val removed = TripMemberRepository.removeMember(tripId, memberId)
+    if (!removed) {
+        throw SyncApplyException(REASON_NOT_FOUND)
+    }
+}
+
+private fun applyIdeaStatusUpsert(userId: String, item: SyncPushItem) {
+    val ideaId = normalizeUuid(item.id)
+    val existing = IdeaRepository.get(ideaId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (!TripRepository.isOwner(existing.tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val payload = decodePayload<SyncIdeaStatusUpsertPayload>(item.payload)
+    val status = payload.status.trim().lowercase()
+    if (status != "approved" && status != "rejected") {
+        throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    }
+    if (existing.status == status) {
+        return
+    }
+    val updated = IdeaRepository.updateStatus(ideaId, status)
+    if (updated == null) {
+        throw SyncApplyException(REASON_NOT_FOUND)
+    }
+}
+
+private fun applyIdeaConvertCreate(userId: String, item: SyncPushItem) {
+    val ideaId = normalizeUuid(item.id)
+    val idea = IdeaRepository.get(ideaId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (!TripRepository.isMember(idea.tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val payload = decodePayload<SyncIdeaConvertCreatePayload>(item.payload)
+    val dayId = normalizeUuid(payload.dayId)
+    val dayTripId = DayRepository.findTripIdByDayId(dayId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (dayTripId != idea.tripId) {
+        throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    }
+
+    val existingActivity = ActivityRepository.findBySourceIdea(dayId = dayId, sourceIdeaId = ideaId)
+    if (existingActivity != null) {
+        return
+    }
+
+    val orderIndex = payload.orderIndex ?: ActivityRepository.nextOrderIndex(dayId)
+    ActivityRepository.createFromIdea(
+        dayId = dayId,
+        idea = idea,
+        timeText = payload.timeText,
+        orderIndex = orderIndex,
+    )
+}
+
+private fun applyActivityReorderUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncActivityReorderUpsertPayload>(item.payload)
+    val rawDayId = payload.dayId.ifBlank { item.id }
+    val dayId = normalizeUuid(rawDayId)
+    val tripId = DayRepository.findTripIdByDayId(dayId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (!TripRepository.isMember(tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+
+    val orderedIds = payload.orderedIds.map(::normalizeUuid)
+    ActivityRepository.reorder(dayId, orderedIds)
+}
+
+private fun applyItineraryTrimUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncItineraryTrimUpsertPayload>(item.payload)
+    val tripId = normalizeUuid(payload.tripId)
+    if (!TripRepository.isMember(tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+    val dayIds = payload.dayIds.map(::normalizeUuid)
+
+    when (payload.action.trim().lowercase()) {
+        "keep" -> ItineraryDayRepository.markOutOfRange(dayIds, true)
+        "remove" -> ItineraryDayRepository.deleteDays(dayIds)
+        "extend_end" -> {
+            val updated = TripRepository.extendTripEndByOutOfRangeDays(
+                ownerId = userId,
+                tripId = tripId,
+                dayIds = dayIds,
+            )
+            if (updated == null) {
+                throw SyncApplyException(REASON_FORBIDDEN)
+            }
+        }
+
+        else -> throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    }
+}
+
+private fun applyNotificationSettingsUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncNotificationSettingsUpsertPayload>(item.payload)
+    val rows = payload.items.map { setting ->
+        val key = setting.key.trim()
+        if (key.isBlank()) {
+            throw SyncApplyException(REASON_INVALID_PAYLOAD)
+        }
+        NotificationSettingRow(
+            userId = userId,
+            key = key,
+            enabled = setting.enabled,
+        )
+    }
+    NotificationRepository.upsertSettings(userId, rows)
+}
+
+private fun applyNotificationReadUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncNotificationReadUpsertPayload>(item.payload)
+    when (payload.mode.trim().lowercase()) {
+        "single" -> {
+            val rawId = payload.notificationId?.trim().orEmpty().ifBlank { item.id.trim() }
+            val notificationId = normalizeUuid(rawId)
+            val updated = NotificationRepository.markRead(userId, notificationId)
+            if (!updated) {
+                val exists = NotificationRepository.listForUser(userId).any { it.id == notificationId }
+                if (!exists) {
+                    throw SyncApplyException(REASON_NOT_FOUND)
+                }
+            }
+        }
+
+        READ_BULK_MODE_NON_COMMENT -> NotificationRepository.markReadBulkNonComment(userId)
+        READ_BULK_MODE_IDEA_COMMENTS -> {
+            val ideaId = payload.ideaId?.trim().orEmpty()
+            if (ideaId.isBlank()) {
+                throw SyncApplyException(REASON_INVALID_PAYLOAD)
+            }
+            NotificationRepository.markReadBulkIdeaComments(userId, normalizeUuid(ideaId))
+        }
+
+        else -> throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    }
+}
+
+private fun applyUserProfileUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncUserProfileUpsertPayload>(item.payload)
+    val existing = UserRepository.findById(userId) ?: throw SyncApplyException(REASON_NOT_FOUND)
+
+    val normalizedName = payload.name.trim().takeIf { it.isNotBlank() }
+        ?: throw SyncApplyException(REASON_INVALID_PAYLOAD)
+    val normalizedPhotoUrl = when (val raw = payload.photoUrl) {
+        null -> existing.photoUrl
+        else -> raw.trim().takeIf { it.isNotBlank() }
+    }
+
+    val updated = UserRepository.updateUser(
+        userId = userId,
+        name = normalizedName,
+        photoUrl = normalizedPhotoUrl,
+    )
+    if (updated == null) {
+        throw SyncApplyException(REASON_NOT_FOUND)
+    }
+}
+
+private fun applyAiSuggestionSaveUpsert(userId: String, item: SyncPushItem) {
+    val payload = decodePayload<SyncAiSuggestionSaveUpsertPayload>(item.payload)
+    val suggestionIdRaw = payload.suggestionId?.trim().orEmpty().ifBlank { item.id.trim() }
+    val suggestionId = normalizeUuid(suggestionIdRaw)
+
+    val suggestion = AiRepository.getSuggestionWithRequest(suggestionId)
+        ?: throw SyncApplyException(REASON_DEPENDENCY_NOT_READY, retryable = true)
+    if (!TripRepository.isMember(suggestion.tripId, userId)) {
+        throw SyncApplyException(REASON_FORBIDDEN)
+    }
+    if (suggestion.suggestion.isSaved) {
+        return
+    }
+
+    val idea = IdeaRepository.create(
+        tripId = suggestion.tripId,
+        authorId = userId,
+        title = suggestion.suggestion.title,
+        city = suggestion.suggestion.place?.trim()?.ifBlank { null },
+        link = null,
+        costAmount = suggestion.suggestion.estimatedCost,
+        costType = null,
+        notes = suggestion.suggestion.description ?: suggestion.requestDescription,
+    )
+    AiRepository.markSuggestionSaved(suggestionId, idea.id)
 }
 
 private fun normalizeEntity(raw: String): String {

--- a/backend/src/test/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutesTest.kt
+++ b/backend/src/test/kotlin/nvk/cotrip/backend/routes/v1/SyncRoutesTest.kt
@@ -9,9 +9,14 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import nvk.cotrip.backend.testing.DbFixtureSupport.createIdea
+import nvk.cotrip.backend.testing.DbFixtureSupport.createTrip
+import nvk.cotrip.backend.testing.DbFixtureSupport.id
+import nvk.cotrip.backend.testing.DbFixtureSupport.joinTrip
+import nvk.cotrip.backend.testing.DbFixtureSupport.listItineraryDays
 import nvk.cotrip.backend.testing.PostgresIntegrationTest
 import nvk.cotrip.backend.testing.TestApplicationSupport
 import kotlin.test.Test
@@ -295,10 +300,307 @@ class SyncRoutesTest {
         assertEquals(HttpStatusCode.BadRequest, response.status)
     }
 
+    @Test
+    fun given_newCommandEntities_when_postSyncChanges_then_happyPathApplies() = withApp { owner ->
+        // GIVEN
+        val trip = createTrip(accessToken = owner.accessToken, title = "Sync Commands Trip")
+        val tripId = trip.id()
+        val dayId = listItineraryDays(owner.accessToken, tripId).first().jsonObject["id"]!!.jsonPrimitive.content
+        val member = createDevSession(googleId = "sync-member-${randomUuid()}", name = "Sync Member")
+        joinTrip(accessToken = member.accessToken, tripId = tripId)
+        val memberIdea = createIdea(accessToken = member.accessToken, tripId = tripId, title = "Member Idea")
+        val ideaId = memberIdea.id()
+
+        val activityCreateResponse = client.post("/v1/sync/changes") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer ${owner.accessToken}")
+            setBody(
+                """
+                {
+                  "items": [
+                    {
+                      "changeId": "create-activity-1",
+                      "entity": "activity",
+                      "id": "${randomUuid()}",
+                      "type": "create",
+                      "payload": {"dayId":"$dayId","title":"A1"}
+                    },
+                    {
+                      "changeId": "create-activity-2",
+                      "entity": "activity",
+                      "id": "${randomUuid()}",
+                      "type": "create",
+                      "payload": {"dayId":"$dayId","title":"A2"}
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+        }
+        assertEquals(HttpStatusCode.OK, activityCreateResponse.status)
+
+        val aiResponse = client.post("/v1/trips/$tripId/ai/suggestions") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer ${owner.accessToken}")
+            setBody("""{"city":"Paris","typeOptions":["Museum"]}""")
+        }
+        assertEquals(HttpStatusCode.OK, aiResponse.status)
+        val aiSuggestionId = json.parseToJsonElement(aiResponse.body<String>())
+            .jsonObject["items"]!!.jsonArray.first().jsonObject["id"]!!.jsonPrimitive.content
+
+        // WHEN
+        val response = client.post("/v1/sync/changes") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer ${owner.accessToken}")
+            setBody(
+                """
+                {
+                  "items": [
+                    {
+                      "changeId": "trip-member-delete",
+                      "entity": "trip_member",
+                      "id": "$tripId:${member.userId}",
+                      "type": "delete",
+                      "payload": {"tripId":"$tripId","memberId":"${member.userId}"}
+                    },
+                    {
+                      "changeId": "idea-status",
+                      "entity": "idea_status",
+                      "id": "$ideaId",
+                      "type": "upsert",
+                      "payload": {"status":"approved"}
+                    },
+                    {
+                      "changeId": "idea-convert",
+                      "entity": "idea_convert",
+                      "id": "$ideaId",
+                      "type": "create",
+                      "payload": {"dayId":"$dayId"}
+                    },
+                    {
+                      "changeId": "activity-reorder",
+                      "entity": "activity_reorder",
+                      "id": "$dayId",
+                      "type": "upsert",
+                      "payload": {"dayId":"$dayId","orderedIds":[]}
+                    },
+                    {
+                      "changeId": "itinerary-trim",
+                      "entity": "itinerary_trim",
+                      "id": "$tripId",
+                      "type": "upsert",
+                      "payload": {"tripId":"$tripId","action":"keep","dayIds":[]}
+                    },
+                    {
+                      "changeId": "notification-settings",
+                      "entity": "notification_settings",
+                      "id": "me",
+                      "type": "upsert",
+                      "payload": {"items":[{"key":"expenses_new","enabled":false}]}
+                    },
+                    {
+                      "changeId": "notification-read",
+                      "entity": "notification_read",
+                      "id": "non_comment",
+                      "type": "upsert",
+                      "payload": {"mode":"non_comment"}
+                    },
+                    {
+                      "changeId": "user-profile",
+                      "entity": "user_profile",
+                      "id": "me",
+                      "type": "upsert",
+                      "payload": {"name":"Owner Renamed"}
+                    },
+                    {
+                      "changeId": "ai-save",
+                      "entity": "ai_suggestion_save",
+                      "id": "$aiSuggestionId",
+                      "type": "upsert",
+                      "payload": {"suggestionId":"$aiSuggestionId"}
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+        }
+
+        // THEN
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.body<String>()).jsonObject
+        val applied = body["applied"]!!.jsonArray.map { it.jsonPrimitive.content }.toSet()
+        val conflicts = body["conflicts"]!!.jsonArray
+        assertTrue(conflicts.isEmpty())
+        assertEquals(
+            setOf(
+                "trip-member-delete",
+                "idea-status",
+                "idea-convert",
+                "activity-reorder",
+                "itinerary-trim",
+                "notification-settings",
+                "notification-read",
+                "user-profile",
+                "ai-save",
+            ),
+            applied
+        )
+    }
+
+    @Test
+    fun given_newCommandsWithForbiddenAndInvalidPayload_when_postSyncChanges_then_conflictsContainReasons() = withApp { owner ->
+        // GIVEN
+        val trip = createTrip(accessToken = owner.accessToken, title = "Sync Commands Failures")
+        val tripId = trip.id()
+        val dayId = listItineraryDays(owner.accessToken, tripId).first().jsonObject["id"]!!.jsonPrimitive.content
+        val member = createDevSession(googleId = "sync-member-forbidden-${randomUuid()}", name = "Forbidden Member")
+        joinTrip(accessToken = member.accessToken, tripId = tripId)
+
+        // WHEN
+        val response = client.post("/v1/sync/changes") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer ${member.accessToken}")
+            setBody(
+                """
+                {
+                  "items": [
+                    {
+                      "changeId": "forbidden-member-delete-owner",
+                      "entity": "trip_member",
+                      "id": "$tripId:${owner.userId}",
+                      "type": "delete",
+                      "payload": {"tripId":"$tripId","memberId":"${owner.userId}"}
+                    },
+                    {
+                      "changeId": "invalid-idea-status",
+                      "entity": "idea_status",
+                      "id": "${randomUuid()}",
+                      "type": "upsert",
+                      "payload": {"status":"broken"}
+                    },
+                    {
+                      "changeId": "invalid-trim-action",
+                      "entity": "itinerary_trim",
+                      "id": "$tripId",
+                      "type": "upsert",
+                      "payload": {"tripId":"$tripId","action":"bad","dayIds":[]}
+                    },
+                    {
+                      "changeId": "invalid-notification-read",
+                      "entity": "notification_read",
+                      "id": "x",
+                      "type": "upsert",
+                      "payload": {"mode":"idea_comments"}
+                    },
+                    {
+                      "changeId": "invalid-user-profile",
+                      "entity": "user_profile",
+                      "id": "me",
+                      "type": "upsert",
+                      "payload": {"name":"  "}
+                    },
+                    {
+                      "changeId": "invalid-activity-reorder",
+                      "entity": "activity_reorder",
+                      "id": "$dayId",
+                      "type": "upsert",
+                      "payload": {"dayId":"$dayId","orderedIds":["not-a-uuid"]}
+                    }
+                  ]
+                }
+                """.trimIndent()
+            )
+        }
+
+        // THEN
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.body<String>()).jsonObject
+        val conflicts = body["conflicts"]!!.jsonArray.map { it.jsonObject }
+        assertEquals(6, conflicts.size)
+        val reasons = conflicts.associate {
+            it["changeId"]!!.jsonPrimitive.content to it["reason"]!!.jsonPrimitive.content
+        }
+        assertEquals("forbidden", reasons["forbidden-member-delete-owner"])
+        assertEquals("invalid_payload", reasons["invalid-idea-status"])
+        assertEquals("invalid_payload", reasons["invalid-trim-action"])
+        assertEquals("invalid_payload", reasons["invalid-notification-read"])
+        assertEquals("invalid_payload", reasons["invalid-user-profile"])
+        assertEquals("invalid_payload", reasons["invalid-activity-reorder"])
+    }
+
+    @Test
+    fun given_idempotentCommandOps_when_postSyncChangesTwice_then_secondCallHasNoConflicts() = withApp { owner ->
+        // GIVEN
+        val trip = createTrip(accessToken = owner.accessToken, title = "Sync Commands Idempotent")
+        val tripId = trip.id()
+        val idea = createIdea(accessToken = owner.accessToken, tripId = tripId, title = "Idempotent Idea")
+        val ideaId = idea.id()
+
+        val payload = """
+            {
+              "items": [
+                {
+                  "changeId": "idempotent-idea-status",
+                  "entity": "idea_status",
+                  "id": "$ideaId",
+                  "type": "upsert",
+                  "payload": {"status":"approved"}
+                },
+                {
+                  "changeId": "idempotent-notification-settings",
+                  "entity": "notification_settings",
+                  "id": "me",
+                  "type": "upsert",
+                  "payload": {"items":[{"key":"expenses_new","enabled":true}]}
+                },
+                {
+                  "changeId": "idempotent-user-profile",
+                  "entity": "user_profile",
+                  "id": "me",
+                  "type": "upsert",
+                  "payload": {"name":"Owner Stable"}
+                }
+              ]
+            }
+        """.trimIndent()
+
+        // WHEN
+        repeat(2) { index ->
+            val response = client.post("/v1/sync/changes") {
+                contentType(ContentType.Application.Json)
+                header(HttpHeaders.Authorization, "Bearer ${owner.accessToken}")
+                setBody(payload.replace("idempotent-", "idempotent-$index-"))
+            }
+
+            // THEN
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = json.parseToJsonElement(response.body<String>()).jsonObject
+            val conflicts = body["conflicts"]!!.jsonArray
+            assertTrue(conflicts.isEmpty())
+        }
+    }
+
     private fun withApp(
         block: suspend io.ktor.server.testing.ApplicationTestBuilder.(TestApplicationSupport.DevSession) -> Unit,
     ) {
         TestApplicationSupport.withApp(block)
+    }
+
+    private suspend fun io.ktor.server.testing.ApplicationTestBuilder.createDevSession(
+        googleId: String,
+        name: String,
+    ): TestApplicationSupport.DevSession {
+        val response = client.post("/v1/auth/dev") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"googleId":"$googleId","name":"$name"}""")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.body<String>()).jsonObject
+        return TestApplicationSupport.DevSession(
+            accessToken = body["accessToken"]!!.jsonPrimitive.content,
+            refreshToken = body["refreshToken"]!!.jsonPrimitive.content,
+            userId = body["user"]!!.jsonObject["id"]!!.jsonPrimitive.content,
+        )
     }
 
     private fun randomUuid(): String = java.util.UUID.randomUUID().toString()


### PR DESCRIPTION
## Summary
- Extend Android sync entities/payloads and backend `/v1/sync/changes` handling for missing offline command mutations.
- Implement consistent queue coalescing rules (`create+delete` collapse, last-write-wins upserts, singleton command upserts).
- Update repositories to treat supported offline mutations as optimistic local updates plus queued sync instead of surfacing IO failures.
- Add optimistic offline path for AI suggestion save to reflect saved state immediately and sync later.
- Remove non-critical success/info toasts, keep critical-only error toasts, and suppress offline auto-refresh toasts.
- Add inline validation state/UI for Join/Trip/Itinerary flows with error reset on relevant input changes.
- Expand Android and backend tests for new sync entities, queue behavior, toast policy changes, and integration/idempotency paths.

## Testing
- `:app:testDebugUnitTest` (targeted repository/sync/UI tests)
- `./gradlew test --tests "nvk.cotrip.backend.routes.v1.SyncRoutesTest" --rerun-tasks`