### PR TITLE
CI: build and sign release APK on each push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ name: CI
 on:
   push:
     branches: [main, master]
-    paths:
-      - 'backend/**'
-      - 'android/**'
-      - 'quality-check.sh'
-      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main, master]
     paths:
@@ -112,3 +107,94 @@ jobs:
             android/app/build/reports/tests/testDebugUnitTest
             android/app/build/test-results/testDebugUnitTest
           if-no-files-found: ignore
+
+  android-release-apk:
+    name: Android Release APK
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+      ANDROID_RELEASE_KEYSTORE_B64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}
+      ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
+      ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+      ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore google-services.json from secret
+        if: ${{ env.ANDROID_GOOGLE_SERVICES_JSON_B64 != '' }}
+        run: |
+          echo "$ANDROID_GOOGLE_SERVICES_JSON_B64" | base64 --decode > android/app/google-services.json
+
+      - name: Continue without google-services.json
+        if: ${{ env.ANDROID_GOOGLE_SERVICES_JSON_B64 == '' }}
+        run: echo "ANDROID_GOOGLE_SERVICES_JSON_B64 is not set, build continues without google-services.json"
+
+      - name: Validate Android signing secrets
+        run: |
+          missing=0
+          for key in \
+            ANDROID_RELEASE_KEYSTORE_B64 \
+            ANDROID_RELEASE_KEYSTORE_PASSWORD \
+            ANDROID_RELEASE_KEY_ALIAS \
+            ANDROID_RELEASE_KEY_PASSWORD
+          do
+            if [ -z "${!key}" ]; then
+              echo "Missing required secret: $key"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Restore release keystore from secret
+        run: |
+          echo "$ANDROID_RELEASE_KEYSTORE_B64" | base64 --decode > android/release-keystore.jks
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x android/gradlew
+
+      - name: Assemble release APK
+        working-directory: android
+        run: ./gradlew :app:assembleRelease
+
+      - name: Sign release APK
+        working-directory: android
+        run: |
+          BUILD_TOOLS_VERSION="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n1)"
+          BUILD_TOOLS_DIR="$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION"
+
+          UNSIGNED_APK="app/build/outputs/apk/release/app-release-unsigned.apk"
+          ALIGNED_APK="app/build/outputs/apk/release/app-release-aligned.apk"
+          SIGNED_APK="app/build/outputs/apk/release/app-release-signed.apk"
+
+          "$BUILD_TOOLS_DIR/zipalign" -f -p 4 "$UNSIGNED_APK" "$ALIGNED_APK"
+          "$BUILD_TOOLS_DIR/apksigner" sign \
+            --ks release-keystore.jks \
+            --ks-key-alias "$ANDROID_RELEASE_KEY_ALIAS" \
+            --ks-pass "pass:$ANDROID_RELEASE_KEYSTORE_PASSWORD" \
+            --key-pass "pass:$ANDROID_RELEASE_KEY_PASSWORD" \
+            --out "$SIGNED_APK" \
+            "$ALIGNED_APK"
+
+          "$BUILD_TOOLS_DIR/apksigner" verify --verbose "$SIGNED_APK"
+
+      - name: Remove release keystore
+        if: always()
+        run: rm -f android/release-keystore.jks
+
+      - name: Upload release APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-apk-signed-${{ github.run_number }}
+          path: |
+            android/app/build/outputs/apk/release/app-release-signed.apk
+            android/app/build/outputs/apk/release/output-metadata.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- run CI on every push to `main` (removed `paths` filter for push trigger)
- add `android-release-apk` job that runs only on `push` to `main`
- restore release keystore from GitHub secret and validate required signing secrets
- assemble release APK, align and sign it with `apksigner`
- upload `app-release-signed.apk` as an artifact

## Required secrets
- `ANDROID_RELEASE_KEYSTORE_B64`
- `ANDROID_RELEASE_KEYSTORE_PASSWORD`
- `ANDROID_RELEASE_KEY_ALIAS`
- `ANDROID_RELEASE_KEY_PASSWORD`

## Notes
- keystore file is removed at the end of the job (`if: always()` cleanup step)
- artifact name: `android-release-apk-signed-${{ github.run_number }}`