### PR TITLE
Fix AI generation messaging, discussion visibility, and back navigation double-pop

### DIFF
--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteScreen.kt
@@ -212,20 +212,31 @@ private fun HintCard() {
         border = BorderStroke(1.dp, HintPurpleBorder),
         color = HintPurple
     ) {
-        Row(
+        Column(
             modifier = Modifier.padding(CoTripTokens.spacing.x2),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1)
+            verticalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1)
         ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1)
+            ) {
+                Text(
+                    text = stringResource(R.string.ai_suggestions_hint_symbol),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = HintPurpleText
+                )
+                Text(
+                    text = stringResource(R.string.ai_suggestions_hint),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = HintPurpleText
+                )
+            }
+
             Text(
-                text = stringResource(R.string.ai_suggestions_hint_symbol),
-                style = MaterialTheme.typography.headlineSmall,
-                color = HintPurpleText
-            )
-            Text(
-                text = stringResource(R.string.ai_suggestions_hint),
-                style = MaterialTheme.typography.bodyLarge,
-                color = HintPurpleText
+                text = stringResource(R.string.ai_suggestions_disclaimer),
+                style = MaterialTheme.typography.bodyMedium,
+                color = HintPurpleText,
+                fontWeight = FontWeight.Medium
             )
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
@@ -173,6 +173,11 @@ private fun LoadingState(modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.headlineSmall,
                 color = TextSecondary
             )
+            Text(
+                text = stringResource(R.string.ai_suggestions_disclaimer),
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextSecondary
+            )
         }
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsScreen.kt
@@ -87,6 +87,11 @@ fun IdeaDetailsScreen(
     val context = LocalContext.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val lifecycleOwner = LocalLifecycleOwner.current
+    val selectedTab = if (state.isDiscussionAvailable) {
+        state.selectedTab
+    } else {
+        IdeaDetailsTab.Details
+    }
 
     DisposableEffect(lifecycleOwner, viewModel) {
         val observer = LifecycleEventObserver { _, event ->
@@ -115,8 +120,8 @@ fun IdeaDetailsScreen(
     }
 
     val dayPicker = state.dayPicker
-    DisposableEffect(state.selectedTab, state.ideaId) {
-        if (state.selectedTab == IdeaDetailsTab.Discussion) {
+    DisposableEffect(selectedTab, state.ideaId) {
+        if (selectedTab == IdeaDetailsTab.Discussion) {
             AppRuntimeState.setActiveDiscussionIdeaId(state.ideaId)
         } else {
             AppRuntimeState.clearActiveDiscussionIdeaId(state.ideaId)
@@ -175,7 +180,7 @@ fun IdeaDetailsScreen(
             )
         },
         bottomBar = {
-            when (state.selectedTab) {
+            when (selectedTab) {
                 IdeaDetailsTab.Details -> DetailsBottomBar(
                     addedDay = state.addedDay,
                     onAddClick = { viewModel.onEvent(IdeaDetailsEvent.OnAddToItineraryClick) },
@@ -196,12 +201,13 @@ fun IdeaDetailsScreen(
                 .padding(padding)
         ) {
             IdeaDetailsTabs(
-                selectedTab = state.selectedTab,
+                selectedTab = selectedTab,
+                isDiscussionAvailable = state.isDiscussionAvailable,
                 commentsCount = state.commentsCount,
                 onTabSelected = { viewModel.onEvent(IdeaDetailsEvent.OnTabSelected(it)) }
             )
 
-            when (state.selectedTab) {
+            when (selectedTab) {
                 IdeaDetailsTab.Details -> IdeaDetailsContent(
                     state = state,
                     modifier = Modifier.weight(1f)
@@ -225,6 +231,7 @@ fun IdeaDetailsScreen(
 @Composable
 private fun IdeaDetailsTabs(
     selectedTab: IdeaDetailsTab,
+    isDiscussionAvailable: Boolean,
     commentsCount: Int,
     onTabSelected: (IdeaDetailsTab) -> Unit,
 ) {
@@ -243,24 +250,26 @@ private fun IdeaDetailsTabs(
                 )
             }
         )
-        Tab(
-            selected = selectedTab == IdeaDetailsTab.Discussion,
-            onClick = { onTabSelected(IdeaDetailsTab.Discussion) },
-            text = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x0_5)
-                ) {
-                    Text(
-                        text = stringResource(R.string.idea_details_tab_discussion),
-                        style = MaterialTheme.typography.labelLarge
-                    )
-                    if (commentsCount > 0) {
-                        DiscussionBadge(count = commentsCount)
+        if (isDiscussionAvailable) {
+            Tab(
+                selected = selectedTab == IdeaDetailsTab.Discussion,
+                onClick = { onTabSelected(IdeaDetailsTab.Discussion) },
+                text = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x0_5)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.idea_details_tab_discussion),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                        if (commentsCount > 0) {
+                            DiscussionBadge(count = commentsCount)
+                        }
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsState.kt
@@ -15,6 +15,7 @@ data class IdeaDetailsState(
     val isOwner: Boolean,
     val isUpdatingStatus: Boolean,
     val selectedTab: IdeaDetailsTab,
+    val isDiscussionAvailable: Boolean,
     val commentsCount: Int,
     val discussion: List<IdeaDiscussionItemUi>,
     val commentInput: String,

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
@@ -112,6 +112,7 @@ class IdeaDetailsViewModel @Inject constructor(
             isOwner = false,
             isUpdatingStatus = false,
             selectedTab = IdeaDetailsTab.Details,
+            isDiscussionAvailable = true,
             commentsCount = 0,
             discussion = emptyList(),
             commentInput = "",
@@ -159,6 +160,9 @@ class IdeaDetailsViewModel @Inject constructor(
             IdeaDetailsEvent.OnDismissDayPicker -> dismissDayPicker()
             is IdeaDetailsEvent.OnDaySelected -> selectDay(event.day)
             is IdeaDetailsEvent.OnTabSelected -> {
+                if (event.tab == IdeaDetailsTab.Discussion && !_state.value.isDiscussionAvailable) {
+                    return
+                }
                 _state.update { it.copy(selectedTab = event.tab) }
                 if (event.tab == IdeaDetailsTab.Discussion) {
                     markDiscussionNotificationsRead()
@@ -230,6 +234,8 @@ class IdeaDetailsViewModel @Inject constructor(
                     membersById = membersById,
                     youFallback = youName,
                 )
+                val isDiscussionAvailable = payload.comments.isNotEmpty() ||
+                    payload.membersById.isNotEmpty()
                 _state.update { current ->
                     current.copy(
                         title = payload.idea.title,
@@ -241,6 +247,12 @@ class IdeaDetailsViewModel @Inject constructor(
                         status = payload.idea.status,
                         addedDay = payload.addedDay,
                         isOwner = payload.isOwner,
+                        selectedTab = if (isDiscussionAvailable) {
+                            current.selectedTab
+                        } else {
+                            IdeaDetailsTab.Details
+                        },
+                        isDiscussionAvailable = isDiscussionAvailable,
                         commentsCount = serverDiscussion.count { it is IdeaDiscussionItemUi.Message },
                         discussion = discussion
                     )
@@ -407,6 +419,7 @@ class IdeaDetailsViewModel @Inject constructor(
     }
 
     private fun sendComment() {
+        if (!_state.value.isDiscussionAvailable) return
         val input = _state.value.commentInput.trim()
         if (input.isBlank()) return
         val token = sessionStore.getAccessToken()

--- a/android/app/src/main/java/nvk/cotrip/ui/navigation/AppNavigatorImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/navigation/AppNavigatorImpl.kt
@@ -1,5 +1,6 @@
 package nvk.cotrip.ui.navigation
 
+import android.os.SystemClock
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
 import java.util.concurrent.atomic.AtomicReference
@@ -10,6 +11,8 @@ import javax.inject.Singleton
 class AppNavigatorImpl @Inject constructor() : AppNavigator {
 
     private val controllerRef = AtomicReference<NavHostController?>(null)
+    private var lastPopRoute: String? = null
+    private var lastPopTimestampMs: Long = 0L
 
     fun attachController(controller: NavHostController) {
         controllerRef.set(controller)
@@ -21,6 +24,25 @@ class AppNavigatorImpl @Inject constructor() : AppNavigator {
     }
 
     override fun popBackStack(): Boolean {
-        return controllerRef.get()?.popBackStack() ?: false
+        val controller = controllerRef.get() ?: return false
+        val currentRoute = controller.currentBackStackEntry?.destination?.route
+        val now = SystemClock.elapsedRealtime()
+        val shouldIgnore = synchronized(this) {
+            currentRoute != null &&
+                currentRoute == lastPopRoute &&
+                now - lastPopTimestampMs < POP_BACK_DEBOUNCE_MS
+        }
+        if (shouldIgnore) return false
+
+        val popped = controller.popBackStack()
+        if (popped) {
+            synchronized(this) {
+                lastPopRoute = currentRoute
+                lastPopTimestampMs = now
+            }
+        }
+        return popped
     }
 }
+
+private const val POP_BACK_DEBOUNCE_MS = 350L

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -235,6 +235,7 @@
     <!--AI Suggestions-->
     <string name="ai_suggestions_title">AI-подсказки</string>
     <string name="ai_suggestions_hint">Опишите, что вы ищете, и AI предложит активности под вашу поездку.</string>
+    <string name="ai_suggestions_disclaimer">AI может ошибаться. Проверяйте важные детали перед сохранением.</string>
     <string name="ai_suggestions_city_label">Город *</string>
     <string name="ai_suggestions_city_hint">Города из вашего маршрута</string>
     <string name="ai_suggestions_select_city">Выбрать город</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <!--AI Suggestions-->
     <string name="ai_suggestions_title">AI suggestions</string>
     <string name="ai_suggestions_hint">Describe what you are looking for and the AI will suggest activities tailored to your trip.</string>
+    <string name="ai_suggestions_disclaimer">AI can make mistakes. Double-check important details before saving.</string>
     <string name="ai_suggestions_city_label">City *</string>
     <string name="ai_suggestions_city_hint">Cities from your itinerary</string>
     <string name="ai_suggestions_select_city">Select a city</string>


### PR DESCRIPTION
## Summary
- Add AI disclaimer copy to route generation UI (including loading state) in EN/RU locales
- Hide idea discussion/comments UI when there is no prior discussion and no participants
- Guard idea details tab selection/send-comment flow with discussion availability checks
- Debounce `popBackStack` in `AppNavigatorImpl` to prevent rapid double-back blank-screen navigation

## Testing
- `./gradlew :app:compileDebugKotlin`