### PR TITLE
Fix Google sign-in client ID wiring in CI and guard missing ID crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
-      GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID }}
+      GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID || vars.GOOGLE_SERVER_CLIENT_ID }}
+      HAS_GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID != '' || vars.GOOGLE_SERVER_CLIENT_ID != '' }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Debug Google Sign-In config wiring
+        run: |
+          echo "event_name=$GITHUB_EVENT_NAME"
+          echo "is_fork_pr=${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork || false }}"
+          echo "google_client_id_present=$HAS_GOOGLE_SERVER_CLIENT_ID"
 
       - name: Validate Google Sign-In client id
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: |
-          if [ -z "$GOOGLE_SERVER_CLIENT_ID" ]; then
+          if [ "$HAS_GOOGLE_SERVER_CLIENT_ID" != "true" ]; then
             echo "GOOGLE_SERVER_CLIENT_ID secret is missing."
             echo "Set it in repository Settings -> Secrets and variables -> Actions."
             exit 1
@@ -98,13 +105,13 @@ jobs:
         working-directory: android
         env:
           REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: ./gradlew build -x lint -x :app:testReleaseUnitTest
+        run: ./gradlew build -x lint -x :app:testReleaseUnitTest -PGOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID"
 
       - name: Test & coverage report
         env:
           REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: |
-          cd android && ./gradlew :app:jacocoDebugUnitTestReport && cd ..
+          cd android && ./gradlew :app:jacocoDebugUnitTestReport -PGOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID" && cd ..
           chmod +x .github/scripts/test-coverage-summary.sh
           .github/scripts/test-coverage-summary.sh "Android" \
             android/app/build/test-results/testDebugUnitTest \
@@ -116,7 +123,7 @@ jobs:
         working-directory: android
         env:
           REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        run: ./gradlew :app:qualityCheck
+        run: ./gradlew :app:qualityCheck -PGOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID"
 
       - name: Upload Android test reports on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,13 @@ jobs:
 
       - name: Build
         working-directory: android
+        env:
+          REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: ./gradlew build -x lint -x :app:testReleaseUnitTest
 
       - name: Test & coverage report
+        env:
+          REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: |
           cd android && ./gradlew :app:jacocoDebugUnitTestReport && cd ..
           chmod +x .github/scripts/test-coverage-summary.sh
@@ -110,6 +114,8 @@ jobs:
 
       - name: Quality check
         working-directory: android
+        env:
+          REQUIRE_GOOGLE_SERVER_CLIENT_ID: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         run: ./gradlew :app:qualityCheck
 
       - name: Upload Android test reports on failure

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,12 +31,13 @@ val googleServerClientId = (project.findProperty("GOOGLE_SERVER_CLIENT_ID") as S
     ?: (localProps.getProperty("GOOGLE_SERVER_CLIENT_ID")?.takeIf { it.isNotBlank() })
     ?: (System.getenv("GOOGLE_SERVER_CLIENT_ID")?.takeIf { it.isNotBlank() })
     ?: ""
-val isCiBuild = (System.getenv("CI") ?: "false").equals("true", ignoreCase = true)
+val requireGoogleClientId = (System.getenv("REQUIRE_GOOGLE_SERVER_CLIENT_ID") ?: "false")
+    .equals("true", ignoreCase = true)
 
-if (isCiBuild && googleServerClientId.isBlank()) {
+if (requireGoogleClientId && googleServerClientId.isBlank()) {
     throw GradleException(
-        "GOOGLE_SERVER_CLIENT_ID is required in CI. " +
-            "Provide it via GitHub Actions secret or environment variable."
+        "GOOGLE_SERVER_CLIENT_ID is required for this build. " +
+            "Provide it via GitHub Actions secret/environment or local.properties."
     )
 }
 


### PR DESCRIPTION
## Summary
- Guard `SignInScreen` Google client initialization to avoid startup crashes when `GOOGLE_SERVER_CLIENT_ID` is empty
- Validate Google client ID presence/format in Android CI for trusted contexts
- Add CI debug output for secret wiring (`event_name`, fork status, presence flag)
- Pass `GOOGLE_SERVER_CLIENT_ID` to Gradle explicitly via `-P...` in Android build/test/quality steps
- Enforce required client ID in Gradle only when `REQUIRE_GOOGLE_SERVER_CLIENT_ID=true`
- Add updated launcher asset `android/app/src/main/ic_launcher-playstore-v2.png`

## Testing
- `./gradlew :app:compileReleaseKotlin`
- `./gradlew :app:compileDebugKotlin`