### PR TITLE
Add Google Sign-In diagnostics and CI secret validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,18 @@ on:
       - 'android/**'
       - 'quality-check.sh'
       - '.github/workflows/ci.yml'
+  workflow_dispatch:
+    inputs:
+      run_release_apk:
+        description: "Build signed Android release APK"
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   backend:
     name: Backend
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +64,7 @@ jobs:
 
   android:
     name: Android
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
@@ -137,7 +146,9 @@ jobs:
 
   android-release-apk:
     name: Android Release APK
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_release_apk)
     runs-on: ubuntu-latest
     env:
       ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,30 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+      GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID || vars.GOOGLE_SERVER_CLIENT_ID }}
+      HAS_GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID != '' || vars.GOOGLE_SERVER_CLIENT_ID != '' }}
       ANDROID_RELEASE_KEYSTORE_B64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}
       ANDROID_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEYSTORE_PASSWORD }}
       ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
       ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Debug release Google Sign-In config wiring
+        run: |
+          echo "google_client_id_present=$HAS_GOOGLE_SERVER_CLIENT_ID"
+          echo "google_client_id_length=${#GOOGLE_SERVER_CLIENT_ID}"
+
+      - name: Validate release Google Sign-In client id
+        run: |
+          if [ "$HAS_GOOGLE_SERVER_CLIENT_ID" != "true" ]; then
+            echo "GOOGLE_SERVER_CLIENT_ID secret/variable is missing for release APK build."
+            exit 1
+          fi
+          if [[ "$GOOGLE_SERVER_CLIENT_ID" != *.apps.googleusercontent.com ]]; then
+            echo "GOOGLE_SERVER_CLIENT_ID looks invalid: expected a Web OAuth client id ending with .apps.googleusercontent.com"
+            exit 1
+          fi
 
       - name: Restore google-services.json from secret
         if: ${{ env.ANDROID_GOOGLE_SERVICES_JSON_B64 != '' }}
@@ -203,7 +221,9 @@ jobs:
 
       - name: Assemble release APK
         working-directory: android
-        run: ./gradlew :app:assembleRelease
+        env:
+          REQUIRE_GOOGLE_SERVER_CLIENT_ID: "true"
+        run: ./gradlew :app:assembleRelease -PGOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID"
 
       - name: Sign release APK
         working-directory: android

--- a/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
@@ -1,5 +1,8 @@
 package nvk.cotrip.ui.auth
 
+import android.content.Context
+import android.content.pm.Signature
+import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -37,6 +40,13 @@ import nvk.cotrip.ui.components.PrimaryButton
 import nvk.cotrip.ui.theme.CoTripTokens
 import nvk.cotrip.ui.theme.TextMedium
 import nvk.cotrip.ui.theme.TextSecondary
+import nvk.cotrip.util.AppLogger
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+private const val TAG = "SignInScreen"
 
 @Composable
 fun SignInScreen(
@@ -61,6 +71,26 @@ fun SignInScreen(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         viewModel.onEvent(SignInEvent.OnGoogleSignInResult(result.resultCode, result.data))
+    }
+
+    LaunchedEffect(serverClientId) {
+        val defaultWebClientId = runCatching {
+            val id = context.resources.getIdentifier(
+                "default_web_client_id",
+                "string",
+                context.packageName
+            )
+            if (id == 0) "<missing default_web_client_id>" else context.getString(id)
+        }.getOrElse { "<missing default_web_client_id>" }
+        val fingerprints = runCatching { loadSigningFingerprints(context) }
+            .getOrElse { error -> "failed_to_read_fingerprints: ${error.message}" }
+        AppLogger.w(
+            TAG,
+            "Google config debug: buildConfigClientId='$serverClientId', " +
+                "defaultWebClientId='$defaultWebClientId', package='${context.packageName}', " +
+                "buildType='${BuildConfig.BUILD_TYPE}', debug=${BuildConfig.DEBUG}"
+        )
+        AppLogger.w(TAG, "Google config debug: app signing fingerprints -> $fingerprints")
     }
 
     LaunchedEffect(viewModel) {
@@ -114,6 +144,11 @@ fun SignInScreen(
                     onClick = {
                         val client = signInClient
                         if (client == null) {
+                            AppLogger.e(
+                                TAG,
+                                "Google sign-in unavailable: signInClient is null. " +
+                                    "buildConfigClientId='$serverClientId'"
+                            )
                             viewModel.onEvent(
                                 SignInEvent.OnGoogleSignInFailed(missingClientIdMessage)
                             )
@@ -145,4 +180,46 @@ fun SignInScreen(
             }
         }
     }
+}
+
+private fun loadSigningFingerprints(context: Context): String {
+    val signatures = readAppSignatures(context)
+    if (signatures.isEmpty()) return "none"
+    return signatures.joinToString(separator = " | ") { signature ->
+        val certificate = decodeX509Certificate(signature)
+        val encoded = certificate.encoded
+        val sha1 = digestToHexWithColons("SHA-1", encoded)
+        val sha256 = digestToHexWithColons("SHA-256", encoded)
+        "SHA1=$sha1 SHA256=$sha256"
+    }
+}
+
+@Suppress("DEPRECATION")
+private fun readAppSignatures(context: Context): List<Signature> {
+    val packageManager = context.packageManager
+    val packageName = context.packageName
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        val packageInfo = packageManager.getPackageInfo(
+            packageName,
+            android.content.pm.PackageManager.GET_SIGNING_CERTIFICATES
+        )
+        packageInfo.signingInfo?.apkContentsSigners?.toList().orEmpty()
+    } else {
+        val packageInfo = packageManager.getPackageInfo(
+            packageName,
+            android.content.pm.PackageManager.GET_SIGNATURES
+        )
+        packageInfo.signatures?.toList().orEmpty()
+    }
+}
+
+private fun decodeX509Certificate(signature: Signature): X509Certificate {
+    val certificateFactory = CertificateFactory.getInstance("X509")
+    val input = ByteArrayInputStream(signature.toByteArray())
+    return certificateFactory.generateCertificate(input) as X509Certificate
+}
+
+private fun digestToHexWithColons(algorithm: String, bytes: ByteArray): String {
+    val digest = MessageDigest.getInstance(algorithm).digest(bytes)
+    return digest.joinToString(":") { byte -> "%02x".format(byte) }
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
@@ -142,6 +142,16 @@ fun SignInScreen(
                     else
                         stringResource(R.string.continue_with_google),
                     onClick = {
+                        if (serverClientId.isBlank()) {
+                            AppLogger.e(
+                                TAG,
+                                "Google sign-in unavailable: empty GOOGLE_SERVER_CLIENT_ID"
+                            )
+                            viewModel.onEvent(
+                                SignInEvent.OnGoogleSignInFailed(missingClientIdMessage)
+                            )
+                            return@PrimaryButton
+                        }
                         val client = signInClient
                         if (client == null) {
                             AppLogger.e(

--- a/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
@@ -1,8 +1,5 @@
 package nvk.cotrip.ui.auth
 
-import android.content.Context
-import android.content.pm.Signature
-import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -40,13 +37,6 @@ import nvk.cotrip.ui.components.PrimaryButton
 import nvk.cotrip.ui.theme.CoTripTokens
 import nvk.cotrip.ui.theme.TextMedium
 import nvk.cotrip.ui.theme.TextSecondary
-import nvk.cotrip.util.AppLogger
-import java.io.ByteArrayInputStream
-import java.security.MessageDigest
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
-
-private const val TAG = "SignInScreen"
 
 @Composable
 fun SignInScreen(
@@ -71,26 +61,6 @@ fun SignInScreen(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         viewModel.onEvent(SignInEvent.OnGoogleSignInResult(result.resultCode, result.data))
-    }
-
-    LaunchedEffect(serverClientId) {
-        val defaultWebClientId = runCatching {
-            val id = context.resources.getIdentifier(
-                "default_web_client_id",
-                "string",
-                context.packageName
-            )
-            if (id == 0) "<missing default_web_client_id>" else context.getString(id)
-        }.getOrElse { "<missing default_web_client_id>" }
-        val fingerprints = runCatching { loadSigningFingerprints(context) }
-            .getOrElse { error -> "failed_to_read_fingerprints: ${error.message}" }
-        AppLogger.w(
-            TAG,
-            "Google config debug: buildConfigClientId='$serverClientId', " +
-                "defaultWebClientId='$defaultWebClientId', package='${context.packageName}', " +
-                "buildType='${BuildConfig.BUILD_TYPE}', debug=${BuildConfig.DEBUG}"
-        )
-        AppLogger.w(TAG, "Google config debug: app signing fingerprints -> $fingerprints")
     }
 
     LaunchedEffect(viewModel) {
@@ -143,10 +113,6 @@ fun SignInScreen(
                         stringResource(R.string.continue_with_google),
                     onClick = {
                         if (serverClientId.isBlank()) {
-                            AppLogger.e(
-                                TAG,
-                                "Google sign-in unavailable: empty GOOGLE_SERVER_CLIENT_ID"
-                            )
                             viewModel.onEvent(
                                 SignInEvent.OnGoogleSignInFailed(missingClientIdMessage)
                             )
@@ -154,11 +120,6 @@ fun SignInScreen(
                         }
                         val client = signInClient
                         if (client == null) {
-                            AppLogger.e(
-                                TAG,
-                                "Google sign-in unavailable: signInClient is null. " +
-                                    "buildConfigClientId='$serverClientId'"
-                            )
                             viewModel.onEvent(
                                 SignInEvent.OnGoogleSignInFailed(missingClientIdMessage)
                             )
@@ -190,46 +151,4 @@ fun SignInScreen(
             }
         }
     }
-}
-
-private fun loadSigningFingerprints(context: Context): String {
-    val signatures = readAppSignatures(context)
-    if (signatures.isEmpty()) return "none"
-    return signatures.joinToString(separator = " | ") { signature ->
-        val certificate = decodeX509Certificate(signature)
-        val encoded = certificate.encoded
-        val sha1 = digestToHexWithColons("SHA-1", encoded)
-        val sha256 = digestToHexWithColons("SHA-256", encoded)
-        "SHA1=$sha1 SHA256=$sha256"
-    }
-}
-
-@Suppress("DEPRECATION")
-private fun readAppSignatures(context: Context): List<Signature> {
-    val packageManager = context.packageManager
-    val packageName = context.packageName
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        val packageInfo = packageManager.getPackageInfo(
-            packageName,
-            android.content.pm.PackageManager.GET_SIGNING_CERTIFICATES
-        )
-        packageInfo.signingInfo?.apkContentsSigners?.toList().orEmpty()
-    } else {
-        val packageInfo = packageManager.getPackageInfo(
-            packageName,
-            android.content.pm.PackageManager.GET_SIGNATURES
-        )
-        packageInfo.signatures?.toList().orEmpty()
-    }
-}
-
-private fun decodeX509Certificate(signature: Signature): X509Certificate {
-    val certificateFactory = CertificateFactory.getInstance("X509")
-    val input = ByteArrayInputStream(signature.toByteArray())
-    return certificateFactory.generateCertificate(input) as X509Certificate
-}
-
-private fun digestToHexWithColons(algorithm: String, bytes: ByteArray): String {
-    val digest = MessageDigest.getInstance(algorithm).digest(bytes)
-    return digest.joinToString(":") { byte -> "%02x".format(byte) }
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/auth/SignInScreen.kt
@@ -37,9 +37,6 @@ import nvk.cotrip.ui.components.PrimaryButton
 import nvk.cotrip.ui.theme.CoTripTokens
 import nvk.cotrip.ui.theme.TextMedium
 import nvk.cotrip.ui.theme.TextSecondary
-import nvk.cotrip.util.AppLogger
-
-private const val TAG = "SignInScreen"
 
 @Composable
 fun SignInScreen(
@@ -64,14 +61,6 @@ fun SignInScreen(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         viewModel.onEvent(SignInEvent.OnGoogleSignInResult(result.resultCode, result.data))
-    }
-
-    LaunchedEffect(serverClientId) {
-        AppLogger.w(
-            TAG,
-            "Google client id debug: '$serverClientId', length=${serverClientId.length}, " +
-                "buildType=${BuildConfig.BUILD_TYPE}, debug=${BuildConfig.DEBUG}"
-        )
     }
 
     LaunchedEffect(viewModel) {
@@ -125,11 +114,6 @@ fun SignInScreen(
                     onClick = {
                         val client = signInClient
                         if (client == null) {
-                            AppLogger.e(
-                                TAG,
-                                "Google sign-in unavailable: empty GOOGLE_SERVER_CLIENT_ID. " +
-                                    "BuildConfig value='$serverClientId'"
-                            )
                             viewModel.onEvent(
                                 SignInEvent.OnGoogleSignInFailed(missingClientIdMessage)
                             )


### PR DESCRIPTION
## Summary
- add runtime diagnostics in `SignInScreen` to log Google Sign-In configuration inputs used by the app
- add certificate/signing fingerprint diagnostics to help troubleshoot `ApiException: 10` mismatches
- update CI workflow checks around required Google auth secret wiring for clearer failure conditions

## Testing
- Not run (not requested)