### PR TITLE
Remove sensitive auth logs and support legacy Google audience fallback

### DIFF
--- a/android/app/src/main/java/nvk/cotrip/data/network/ApiCaller.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/ApiCaller.kt
@@ -21,8 +21,7 @@ class ApiCaller @Inject constructor(
             val apiError = parseError(e)
             AppLogger.w(
                 TAG,
-                "HTTP ${e.code()} in $operation, apiCode=${apiError?.code.orEmpty()}",
-                e
+                "HTTP ${e.code()} in $operation"
             )
             ApiResult.Failure(
                 error = apiError,
@@ -30,12 +29,12 @@ class ApiCaller @Inject constructor(
                 cause = e,
             )
         } catch (e: IOException) {
-            AppLogger.w(TAG, "Network error in $operation", e)
+            AppLogger.w(TAG, "Network error in $operation")
             ApiResult.Failure(cause = e)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            AppLogger.e(TAG, "Unexpected error in $operation", e)
+            AppLogger.e(TAG, "Unexpected error in $operation")
             ApiResult.Failure(cause = e)
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/auth/SignInViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/auth/SignInViewModel.kt
@@ -2,7 +2,6 @@ package nvk.cotrip.ui.auth
 
 import android.app.Activity
 import android.content.Intent
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -106,9 +105,6 @@ class SignInViewModel @Inject constructor(
                 else -> it.localizedMessage
                     ?: appContext.getString(R.string.sign_in_error_google_failed)
             }
-            if (code != null) {
-                Log.w(TAG, "Google sign-in failed with statusCode=$code resultCode=$resultCode", it)
-            }
             onEvent(
                 SignInEvent.OnGoogleSignInFailed(message)
             )
@@ -132,7 +128,6 @@ class SignInViewModel @Inject constructor(
                 authRepository.signInWithGoogle(idToken)
             }) {
                 is ApiResult.Success -> {
-                    Log.d(TAG, "sign in success")
                     refreshScheduler.scheduleImmediate()
                     runCatching { pushTokenSyncManager.syncCurrentToken() }
                     navigator.navigate(Destination.Trips) {
@@ -142,16 +137,11 @@ class SignInViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    Log.e(TAG, "sign in error", result.cause)
                     _effects.tryEmit(SignInEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
                     _uiState.update { it.copy(isLoading = false) }
                 }
             }
         }
-    }
-
-    companion object {
-        private const val TAG = "SignInViewModel"
     }
 
     private fun mapGoogleSignInError(code: Int, fallbackMessage: String): String {

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,6 +22,7 @@ Auth-related env vars:
 - `JWT_REFRESH_TTL_DAYS` (optional, default `30`)
 - `AUTH_MAX_ACTIVE_SESSIONS` (optional, default `5`)
 - `GOOGLE_ALLOWED_AUDIENCES` (comma-separated Google OAuth client IDs for `/v1/auth/google`)
+- `GOOGLE_SERVER_CLIENT_ID` (legacy fallback for a single Google OAuth client ID when `GOOGLE_ALLOWED_AUDIENCES` is not set)
 
 Android App Links (for opening invite links in the app) are served from:
 `/.well-known/assetlinks.json`

--- a/backend/src/main/kotlin/nvk/cotrip/backend/config/ConfigLoader.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/config/ConfigLoader.kt
@@ -11,6 +11,12 @@ fun loadConfig(config: ApplicationConfig): AppConfig {
             ?: error("Missing required config: $envName (or $configKey)")
     }
 
+    val googleAudienceSource = System.getenv("GOOGLE_ALLOWED_AUDIENCES")
+        ?: config.propertyOrNull("ktor.jwt.googleAllowedAudiences")?.getString()
+        // Backward compatibility: some deployments still provide a single audience this way.
+        ?: System.getenv("GOOGLE_SERVER_CLIENT_ID")
+        ?: config.propertyOrNull("ktor.jwt.googleServerClientId")?.getString()
+
     val jwt = JwtConfig(
         issuer = config.propertyOrNull("ktor.jwt.issuer")?.getString() ?: "cotrip",
         audience = config.propertyOrNull("ktor.jwt.audience")?.getString() ?: "cotrip",
@@ -31,10 +37,7 @@ fun loadConfig(config: ApplicationConfig): AppConfig {
                 ?: config.propertyOrNull("ktor.jwt.maxActiveSessions")?.getString()?.toIntOrNull()
                 ?: 5
             ).coerceIn(1, 20),
-        googleAllowedAudiences = (
-            System.getenv("GOOGLE_ALLOWED_AUDIENCES")
-                ?: config.propertyOrNull("ktor.jwt.googleAllowedAudiences")?.getString()
-            )
+        googleAllowedAudiences = googleAudienceSource
             .orEmpty()
             .split(',', ';', '\n')
             .map { it.trim() }

--- a/backend/src/test/kotlin/nvk/cotrip/backend/config/ConfigLoaderTest.kt
+++ b/backend/src/test/kotlin/nvk/cotrip/backend/config/ConfigLoaderTest.kt
@@ -159,4 +159,32 @@ class ConfigLoaderTest {
         val loaded = loadConfig(config)
         assertTrue(loaded.jwt.googleAllowedAudiences.isEmpty())
     }
+
+    @Test
+    fun given_legacyGoogleServerClientIdOnly_when_loadConfig_then_usesItAsAllowedAudience() {
+        val config = MapApplicationConfig(
+            "ktor.jwt.issuer" to "i",
+            "ktor.jwt.audience" to "a",
+            "ktor.jwt.realm" to "r",
+            "ktor.jwt.secret" to "s",
+            "ktor.jwt.accessTtlMinutes" to "15",
+            "ktor.jwt.refreshTtlDays" to "30",
+            "ktor.jwt.maxActiveSessions" to "5",
+            "ktor.jwt.googleServerClientId" to "legacy-client-id.apps.googleusercontent.com",
+            "ktor.db.url" to "jdbc:postgresql://localhost/db",
+            "ktor.db.user" to "u",
+            "ktor.db.password" to "p",
+            "ktor.weather.refreshTtlHours" to "8",
+            "ktor.ai.provider" to "mock",
+            "ktor.media.uploadDir" to "d",
+            "ktor.media.maxUploadBytes" to "1048576",
+            "ktor.devAuthEnabled" to "false",
+        )
+
+        val loaded = loadConfig(config)
+        assertEquals(
+            setOf("legacy-client-id.apps.googleusercontent.com"),
+            loaded.jwt.googleAllowedAudiences
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Remove detailed auth-related logging from Android sign-in flow to avoid exposing sensitive runtime details
- Simplify network error logging in `ApiCaller` to avoid leaking backend auth error codes
- Add backend config fallback so Google audience validation uses `GOOGLE_SERVER_CLIENT_ID` when `GOOGLE_ALLOWED_AUDIENCES` is not set
- Add coverage for the fallback behavior in `ConfigLoaderTest`
- Document the legacy fallback env var in backend README

## Testing
- `./gradlew :app:compileDebugKotlin`
- `./gradlew test --tests nvk.cotrip.backend.config.ConfigLoaderTest`