### PR TITLE
feat: UI + offline policy, weather and discussion

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -49,8 +49,8 @@ android {
         applicationId = "nvk.cotrip"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.0.1"
+        versionCode = 3
+        versionName = "1.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/android/app/src/main/java/nvk/cotrip/data/network/AuthInterceptor.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/AuthInterceptor.kt
@@ -3,6 +3,7 @@ package nvk.cotrip.data.network
 import nvk.cotrip.data.auth.SessionStore
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.util.Locale
 
 class AuthInterceptor(
     private val sessionStore: SessionStore,
@@ -10,10 +11,14 @@ class AuthInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val token = sessionStore.getAccessToken()
+        val languageTag = Locale.getDefault().toLanguageTag()
+        val withLanguage = request.newBuilder()
+            .header("Accept-Language", languageTag)
+            .build()
         val authenticated = if (token.isNullOrBlank()) {
-            request
+            withLanguage
         } else {
-            request.newBuilder()
+            withLanguage.newBuilder()
                 .header("Authorization", "Bearer $token")
                 .build()
         }

--- a/android/app/src/main/java/nvk/cotrip/data/network/dto/CommentDtos.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/dto/CommentDtos.kt
@@ -11,4 +11,6 @@ data class CommentDto(
     val type: String = "user",
     val body: String,
     val createdAt: String,
+    val systemKey: String? = null,
+    val systemActorName: String? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/data/network/dto/IdeaDtos.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/dto/IdeaDtos.kt
@@ -43,4 +43,5 @@ data class IdeaDto(
     val status: String,
     val updatedAt: String,
     val commentsCount: Int = 0,
+    val hasHumanCommentHistory: Boolean? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/data/network/dto/WeatherDtos.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/dto/WeatherDtos.kt
@@ -25,4 +25,5 @@ data class WeatherForecastResponseDto(
     val availableTo: String? = null,
     val missingDates: List<String> = emptyList(),
     val nextRefreshAt: String? = null,
+    val displayCity: String? = null,
 )

--- a/android/app/src/main/java/nvk/cotrip/data/network/ws/CommentsWebSocket.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/network/ws/CommentsWebSocket.kt
@@ -163,6 +163,8 @@ data class CommentCreatedPayload(
     val body: String,
     val createdAt: String,
     val clientMessageId: String? = null,
+    val systemKey: String? = null,
+    val systemActorName: String? = null,
 )
 
 @Serializable

--- a/android/app/src/main/java/nvk/cotrip/data/repository/AiSuggestionsRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/AiSuggestionsRepositoryImpl.kt
@@ -4,14 +4,9 @@ import javax.inject.Inject
 import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.dto.AiSuggestionDto
 import nvk.cotrip.data.network.dto.AiSuggestionsRequestDto
-import nvk.cotrip.data.sync.SyncAiSuggestionSaveUpsertPayload
-import nvk.cotrip.data.sync.SyncEntities
-import nvk.cotrip.data.sync.SyncQueueRepository
-import java.io.IOException
 
 class AiSuggestionsRepositoryImpl @Inject constructor(
     private val api: CoTripApi,
-    private val syncQueueRepository: SyncQueueRepository,
 ) : AiSuggestionsRepository {
     override suspend fun generateSuggestions(
         tripId: String,
@@ -21,14 +16,6 @@ class AiSuggestionsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveSuggestionToIdeas(suggestionId: String) {
-        try {
-            api.saveAiSuggestionToIdeas(suggestionId)
-        } catch (e: IOException) {
-            syncQueueRepository.enqueueUpsert(
-                entity = SyncEntities.AI_SUGGESTION_SAVE,
-                id = suggestionId,
-                payload = SyncAiSuggestionSaveUpsertPayload(suggestionId = suggestionId),
-            )
-        }
+        api.saveAiSuggestionToIdeas(suggestionId)
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
@@ -74,7 +74,7 @@ class ExpenseRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.EXPENSE, expenseId, request)
             applyExpenseUpdateLocally(expenseId = expenseId, request = request)
-            return
+            throw OfflineWriteQueuedException(cause = e)
         }
         safeLocalMutation("updateExpense.upsertExpense(expenseId=$expenseId)") {
             expensesCacheStore.upsertExpense(updated.tripId, updated)
@@ -87,10 +87,14 @@ class ExpenseRepositoryImpl @Inject constructor(
         val expenseTripId = cachedTripId ?: runCatching { api.getExpense(expenseId).tripId }
             .onFailure { AppLogger.w(TAG, "deleteExpense prefetch failed for expenseId=$expenseId", it) }
             .getOrNull()
+        var offlineQueued = false
+        var offlineCause: IOException? = null
         try {
             api.deleteExpense(expenseId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.EXPENSE, expenseId)
+            offlineQueued = true
+            offlineCause = e
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteExpense got 404 for expenseId=$expenseId, treating as already deleted")
@@ -99,6 +103,9 @@ class ExpenseRepositoryImpl @Inject constructor(
             safeLocalMutation("deleteExpense.removeExpense(expenseId=$expenseId)") {
                 expensesCacheStore.removeExpense(expenseTripId, expenseId)
             }
+        }
+        if (offlineQueued) {
+            throw OfflineWriteQueuedException(cause = offlineCause)
         }
     }
 

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ExpenseRepositoryImpl.kt
@@ -15,13 +15,11 @@ import nvk.cotrip.data.network.dto.ExpenseParticipantDto
 import nvk.cotrip.data.network.dto.ExpenseUpdateRequest
 import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncEntities
-import nvk.cotrip.data.sync.SyncExpenseCreatePayload
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.OffsetDateTime
-import java.util.UUID
 import javax.inject.Inject
 
 class ExpenseRepositoryImpl @Inject constructor(
@@ -63,55 +61,11 @@ class ExpenseRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createExpense(tripId: String, request: ExpenseCreateRequest): ExpenseDto {
-        return try {
-            val expense = api.createExpense(tripId, request)
-            safeLocalMutation("createExpense.upsertExpense(tripId=$tripId, expenseId=${expense.id})") {
-                expensesCacheStore.upsertExpense(tripId, expense)
-            }
-            expense
-        } catch (e: IOException) {
-            val localExpense = ExpenseDto(
-                id = UUID.randomUUID().toString(),
-                tripId = tripId,
-                title = request.title,
-                amount = request.amount,
-                currencyCode = request.currencyCode ?: "EUR",
-                status = request.status,
-                paidById = request.paidById,
-                date = request.date,
-                splitType = request.splitType,
-                note = request.note,
-                participants = request.participants.map { participant ->
-                    ExpenseParticipantDto(
-                        userId = participant.userId,
-                        shareAmount = participant.shareAmount,
-                        isIncluded = participant.isIncluded,
-                        isPaid = participant.isPaid,
-                        name = null,
-                    )
-                },
-            )
-            safeLocalMutation("createExpense.offlineUpsert(expenseId=${localExpense.id})") {
-                expensesCacheStore.upsertExpense(tripId, localExpense)
-            }
-            syncQueueRepository.enqueueCreate(
-                entity = SyncEntities.EXPENSE,
-                id = localExpense.id,
-                payload = SyncExpenseCreatePayload(
-                    tripId = tripId,
-                    title = request.title,
-                    amount = request.amount,
-                    currencyCode = request.currencyCode,
-                    status = request.status,
-                    paidById = request.paidById,
-                    date = request.date,
-                    splitType = request.splitType,
-                    note = request.note,
-                    participants = request.participants,
-                ),
-            )
-            localExpense
+        val expense = api.createExpense(tripId, request)
+        safeLocalMutation("createExpense.upsertExpense(tripId=$tripId, expenseId=${expense.id})") {
+            expensesCacheStore.upsertExpense(tripId, expense)
         }
+        return expense
     }
 
     override suspend fun updateExpense(expenseId: String, request: ExpenseUpdateRequest) {

--- a/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
@@ -8,11 +8,9 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import nvk.cotrip.data.cache.IdeaCommentsCacheStore
 import nvk.cotrip.data.cache.IdeasCacheStore
-import nvk.cotrip.data.cache.ItineraryCacheStore
 import nvk.cotrip.data.cache.UserCacheStore
 import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.NetworkStateProvider
-import nvk.cotrip.data.network.dto.ActivityDto
 import nvk.cotrip.data.network.dto.CommentDto
 import nvk.cotrip.data.network.dto.ConvertIdeaRequest
 import nvk.cotrip.data.network.dto.CreateIdeaRequest
@@ -20,15 +18,12 @@ import nvk.cotrip.data.network.dto.IdeaDto
 import nvk.cotrip.data.network.dto.UpdateIdeaRequest
 import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncEntities
-import nvk.cotrip.data.sync.SyncIdeaConvertCreatePayload
-import nvk.cotrip.data.sync.SyncIdeaCreatePayload
 import nvk.cotrip.data.sync.SyncIdeaStatusUpsertPayload
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
 import java.io.IOException
 import java.time.OffsetDateTime
-import java.util.UUID
 import javax.inject.Inject
 
 class IdeaRepositoryImpl @Inject constructor(
@@ -36,7 +31,6 @@ class IdeaRepositoryImpl @Inject constructor(
     private val syncQueueRepository: SyncQueueRepository,
     private val ideasCacheStore: IdeasCacheStore,
     private val commentsCacheStore: IdeaCommentsCacheStore,
-    private val itineraryCacheStore: ItineraryCacheStore,
     private val userCacheStore: UserCacheStore,
     private val networkStateProvider: NetworkStateProvider,
 ) : IdeaRepository {
@@ -73,45 +67,11 @@ class IdeaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createIdea(tripId: String, request: CreateIdeaRequest): IdeaDto {
-        return try {
-            val idea = api.createIdea(tripId, request)
-            safeLocalMutation("createIdea.upsertIdea(tripId=$tripId, ideaId=${idea.id})") {
-                ideasCacheStore.upsertIdea(tripId, idea)
-            }
-            idea
-        } catch (e: IOException) {
-            val localIdea = IdeaDto(
-                id = UUID.randomUUID().toString(),
-                tripId = tripId,
-                authorId = userCacheStore.getUser()?.id ?: "",
-                title = request.title,
-                city = request.city,
-                link = request.link,
-                costAmount = request.costAmount,
-                costType = request.costType,
-                notes = request.notes,
-                status = "pending",
-                updatedAt = OffsetDateTime.now().toString(),
-                commentsCount = 0,
-            )
-            safeLocalMutation("createIdea.offlineUpsert(ideaId=${localIdea.id})") {
-                ideasCacheStore.upsertIdea(tripId, localIdea)
-            }
-            syncQueueRepository.enqueueCreate(
-                entity = SyncEntities.IDEA,
-                id = localIdea.id,
-                payload = SyncIdeaCreatePayload(
-                    tripId = tripId,
-                    title = request.title,
-                    city = request.city,
-                    link = request.link,
-                    costAmount = request.costAmount,
-                    costType = request.costType,
-                    notes = request.notes,
-                ),
-            )
-            localIdea
+        val idea = api.createIdea(tripId, request)
+        safeLocalMutation("createIdea.upsertIdea(tripId=$tripId, ideaId=${idea.id})") {
+            ideasCacheStore.upsertIdea(tripId, idea)
         }
+        return idea
     }
 
     override suspend fun updateIdea(ideaId: String, request: UpdateIdeaRequest) {
@@ -155,21 +115,7 @@ class IdeaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun convertIdeaToActivity(ideaId: String, request: ConvertIdeaRequest) {
-        try {
-            api.convertIdeaToActivity(ideaId, request).requireSuccess()
-        } catch (e: IOException) {
-            syncQueueRepository.enqueueCreate(
-                entity = SyncEntities.IDEA_CONVERT,
-                id = ideaId,
-                payload = SyncIdeaConvertCreatePayload(
-                    dayId = request.dayId,
-                    timeText = request.timeText,
-                    orderIndex = request.orderIndex,
-                ),
-            )
-            applyIdeaConvertLocally(ideaId = ideaId, request = request)
-            return
-        }
+        api.convertIdeaToActivity(ideaId, request).requireSuccess()
     }
 
     override suspend fun approveIdea(ideaId: String): IdeaDto {
@@ -268,45 +214,5 @@ class IdeaRepositoryImpl @Inject constructor(
             ideasCacheStore.upsertIdea(updated.tripId, updated)
         }
         return updated
-    }
-
-    private suspend fun applyIdeaConvertLocally(
-        ideaId: String,
-        request: ConvertIdeaRequest,
-    ) {
-        val sourceIdea = runCatching { ideasCacheStore.findIdeaById(ideaId) }.getOrNull() ?: return
-        val itineraryByTrip = runCatching { itineraryCacheStore.getAll() }.getOrDefault(emptyMap())
-        val tripId = itineraryByTrip.entries.firstOrNull { (_, days) ->
-            days.any { it.id == request.dayId }
-        }?.key ?: return
-
-        safeLocalMutation("convertIdea.offlineCreateActivity(ideaId=$ideaId,dayId=${request.dayId})") {
-            itineraryCacheStore.updateItinerary(tripId) { days ->
-                days.map { day ->
-                    if (day.id != request.dayId) {
-                        day
-                    } else {
-                        val orderIndex = request.orderIndex
-                            ?: ((day.activities.maxOfOrNull { it.orderIndex } ?: -1) + 1)
-                        val converted = ActivityDto(
-                            id = UUID.randomUUID().toString(),
-                            dayId = day.id,
-                            sourceIdeaId = sourceIdea.id,
-                            title = sourceIdea.title,
-                            timeText = request.timeText,
-                            locationName = sourceIdea.city,
-                            link = sourceIdea.link,
-                            costAmount = sourceIdea.costAmount,
-                            costType = sourceIdea.costType,
-                            notes = sourceIdea.notes,
-                            orderIndex = orderIndex,
-                        )
-                        day.copy(
-                            activities = (day.activities + converted).sortedBy { it.orderIndex }
-                        )
-                    }
-                }
-            }
-        }
     }
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/IdeaRepositoryImpl.kt
@@ -80,7 +80,7 @@ class IdeaRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.IDEA, ideaId, request)
             applyIdeaUpdateLocally(ideaId, request)
-            return
+            throw OfflineWriteQueuedException(cause = e)
         }
         safeLocalMutation("updateIdea.upsertIdea(ideaId=$ideaId)") {
             ideasCacheStore.upsertIdea(updated.tripId, updated)
@@ -92,10 +92,14 @@ class IdeaRepositoryImpl @Inject constructor(
         val ideaTripId = cachedTripId ?: runCatching { api.getIdea(ideaId).tripId }
             .onFailure { AppLogger.w(TAG, "deleteIdea prefetch failed for ideaId=$ideaId", it) }
             .getOrNull()
+        var offlineQueued = false
+        var offlineCause: IOException? = null
         try {
             api.deleteIdea(ideaId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.IDEA, ideaId)
+            offlineQueued = true
+            offlineCause = e
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteIdea got 404 for ideaId=$ideaId, treating as already deleted")
@@ -107,6 +111,9 @@ class IdeaRepositoryImpl @Inject constructor(
         }
         safeLocalMutation("deleteIdea.clearComments(ideaId=$ideaId)") {
             commentsCacheStore.clearIdea(ideaId)
+        }
+        if (offlineQueued) {
+            throw OfflineWriteQueuedException(cause = offlineCause)
         }
     }
 

--- a/android/app/src/main/java/nvk/cotrip/data/repository/InviteRepository.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/InviteRepository.kt
@@ -7,6 +7,7 @@ import nvk.cotrip.data.network.dto.InviteLinkDto
 interface InviteRepository {
     suspend fun createInvite(tripId: String): InviteLinkDto
     fun getInvite(token: String): Flow<InviteInfoDto>
+    suspend fun getInviteForJoin(token: String): InviteInfoDto?
     suspend fun acceptInvite(token: String): String
     suspend fun joinTripById(tripId: String): String
 }

--- a/android/app/src/main/java/nvk/cotrip/data/repository/InviteRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/InviteRepositoryImpl.kt
@@ -30,6 +30,20 @@ class InviteRepositoryImpl @Inject constructor(
         return api.createInvite(tripId)
     }
 
+    override suspend fun getInviteForJoin(token: String): InviteInfoDto? {
+        return if (networkStateProvider.isOnline()) {
+            runCatching { api.getInvite(token) }
+                .onSuccess { invite ->
+                    safeLocalMutation("getInviteForJoin.setInvite(token=$token)") {
+                        inviteCacheStore.setInvite(token, invite)
+                    }
+                }
+                .getOrNull() ?: inviteCacheStore.getInvite(token)
+        } else {
+            inviteCacheStore.getInvite(token)
+        }
+    }
+
     override fun getInvite(token: String): Flow<InviteInfoDto> {
         if (networkStateProvider.isOnline()) {
             ioScope.launch {

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
@@ -19,7 +19,6 @@ import nvk.cotrip.data.network.dto.TrimOutOfRangeRequest
 import nvk.cotrip.data.network.dto.UpdateActivityRequest
 import nvk.cotrip.data.network.dto.UpdateDayRequest
 import nvk.cotrip.data.network.requireSuccess
-import nvk.cotrip.data.sync.SyncActivityCreatePayload
 import nvk.cotrip.data.sync.SyncActivityReorderUpsertPayload
 import nvk.cotrip.data.sync.SyncEntities
 import nvk.cotrip.data.sync.SyncItineraryTrimUpsertPayload
@@ -27,7 +26,6 @@ import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
 import java.io.IOException
-import java.util.UUID
 import javax.inject.Inject
 
 class ItineraryRepositoryImpl @Inject constructor(
@@ -89,41 +87,7 @@ class ItineraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createActivity(dayId: String, request: CreateActivityRequest): ActivityDto {
-        val activity = try {
-            api.createActivity(dayId, request)
-        } catch (e: IOException) {
-            val orderIndex =
-                resolveLocalOrderIndex(dayId = dayId, requestedOrderIndex = request.orderIndex)
-            val localActivity = ActivityDto(
-                id = UUID.randomUUID().toString(),
-                dayId = dayId,
-                sourceIdeaId = null,
-                title = request.title,
-                timeText = request.timeText,
-                locationName = request.locationName,
-                link = request.link,
-                costAmount = request.costAmount,
-                costType = request.costType,
-                notes = request.notes,
-                orderIndex = orderIndex,
-            )
-            syncQueueRepository.enqueueCreate(
-                entity = SyncEntities.ACTIVITY,
-                id = localActivity.id,
-                payload = SyncActivityCreatePayload(
-                    dayId = dayId,
-                    title = request.title,
-                    timeText = request.timeText,
-                    locationName = request.locationName,
-                    link = request.link,
-                    costAmount = request.costAmount,
-                    costType = request.costType,
-                    notes = request.notes,
-                    orderIndex = request.orderIndex,
-                )
-            )
-            localActivity
-        }
+        val activity = api.createActivity(dayId, request)
 
         safeLocalMutation("createActivity.updateItinerary(dayId=$dayId, activityId=${activity.id})") {
             val tripId = findTripIdForDay(dayId) ?: return@safeLocalMutation
@@ -285,15 +249,6 @@ class ItineraryRepositoryImpl @Inject constructor(
             cursor = page.nextCursor
         } while (cursor != null)
         return all
-    }
-
-    private suspend fun resolveLocalOrderIndex(dayId: String, requestedOrderIndex: Int?): Int {
-        if (requestedOrderIndex != null) return requestedOrderIndex
-        val tripId = findTripIdForDay(dayId) ?: return 0
-        val itinerary = itineraryCacheStore.getItinerary(tripId)
-        val day = itinerary.firstOrNull { it.id == dayId } ?: return 0
-        val maxOrder = day.activities.maxOfOrNull { it.orderIndex } ?: -1
-        return maxOrder + 1
     }
 
     private suspend fun applyDayUpdateLocally(

--- a/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/ItineraryRepositoryImpl.kt
@@ -108,7 +108,7 @@ class ItineraryRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.ACTIVITY, activityId, request)
             applyActivityUpdateLocally(activityId = activityId, request = request)
-            return
+            throw OfflineWriteQueuedException(cause = e)
         }
         safeLocalMutation("updateActivity.updateItinerary(activityId=$activityId)") {
             val tripId = findTripIdForDay(updated.dayId) ?: return@safeLocalMutation
@@ -133,7 +133,7 @@ class ItineraryRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             syncQueueRepository.enqueueUpsert(SyncEntities.ACTIVITY, activityId, request)
             applyActivityMoveLocally(activityId = activityId, request = request)
-            return
+            throw OfflineWriteQueuedException(cause = e)
         }
         safeLocalMutation("moveActivity.updateItinerary(activityId=$activityId)") {
             val tripId = findTripIdForDay(request.dayId) ?: return@safeLocalMutation
@@ -154,10 +154,14 @@ class ItineraryRepositoryImpl @Inject constructor(
         val lookup = runCatching { findTripAndDayForActivity(activityId) }
             .onFailure { AppLogger.w(TAG, "deleteActivity lookup failed for activityId=$activityId", it) }
             .getOrNull()
+        var offlineQueued = false
+        var offlineCause: IOException? = null
         try {
             api.deleteActivity(activityId).requireSuccess()
         } catch (e: IOException) {
             syncQueueRepository.enqueueDelete(SyncEntities.ACTIVITY, activityId)
+            offlineQueued = true
+            offlineCause = e
         } catch (e: HttpException) {
             if (e.code() != 404) throw e
             AppLogger.i(TAG, "deleteActivity got 404 for activityId=$activityId, treating as already deleted")
@@ -174,6 +178,9 @@ class ItineraryRepositoryImpl @Inject constructor(
                     }
                 }
             }
+        }
+        if (offlineQueued) {
+            throw OfflineWriteQueuedException(cause = offlineCause)
         }
     }
 

--- a/android/app/src/main/java/nvk/cotrip/data/repository/OfflineWriteQueuedException.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/OfflineWriteQueuedException.kt
@@ -1,0 +1,10 @@
+package nvk.cotrip.data.repository
+
+/**
+ * Thrown after a mutation was applied locally and enqueued for sync.
+ * Callers can distinguish this from a completed remote write without inspecting [nvk.cotrip.data.network.NetworkStateProvider].
+ */
+class OfflineWriteQueuedException(
+    message: String = "Mutation queued for sync when offline",
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/android/app/src/main/java/nvk/cotrip/data/repository/TripRepositoryImpl.kt
+++ b/android/app/src/main/java/nvk/cotrip/data/repository/TripRepositoryImpl.kt
@@ -13,7 +13,6 @@ import nvk.cotrip.data.cache.UserCacheStore
 import nvk.cotrip.data.network.CoTripApi
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.data.network.dto.CreateTripRequest
-import nvk.cotrip.data.network.dto.ItineraryDayDto
 import nvk.cotrip.data.network.dto.MemberDto
 import nvk.cotrip.data.network.dto.TripDto
 import nvk.cotrip.data.network.dto.UpdateTripRequest
@@ -21,14 +20,10 @@ import nvk.cotrip.data.network.requireSuccess
 import nvk.cotrip.data.sync.SyncEntities
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.data.sync.SyncTripMemberDeletePayload
-import nvk.cotrip.data.sync.SyncTripCreateDayPayload
-import nvk.cotrip.data.sync.SyncTripCreatePayload
 import nvk.cotrip.util.AppLogger
 import retrofit2.HttpException
 import java.io.IOException
-import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.UUID
 import javax.inject.Inject
 
 class TripRepositoryImpl @Inject constructor(
@@ -86,49 +81,11 @@ class TripRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createTrip(request: CreateTripRequest): String {
-        return try {
-            val trip = api.createTrip(request)
-            safeLocalMutation("createTrip.upsertTrip(tripId=${trip.id})") {
-                tripsCacheStore.upsertTrip(trip)
-            }
-            trip.id
-        } catch (e: IOException) {
-            val tripId = UUID.randomUUID().toString()
-            val ownerId = userCacheStore.getUser()?.id ?: ""
-            val localTrip = TripDto(
-                id = tripId,
-                ownerId = ownerId,
-                title = request.title,
-                description = request.description,
-                startDate = request.startDate,
-                endDate = request.endDate,
-                locationLine = request.locationLine,
-                coverUrl = request.coverUrl,
-                currencyCode = request.currencyCode,
-                status = "active",
-                updatedAt = OffsetDateTime.now().toString(),
-            )
-            val days = buildLocalDays(request.startDate, request.endDate)
-            safeLocalMutation("createTrip.offlineCache(tripId=$tripId)") {
-                tripsCacheStore.upsertTrip(localTrip)
-                itineraryCacheStore.setItinerary(tripId, days.map { it.toDayDto(tripId) })
-            }
-            syncQueueRepository.enqueueCreate(
-                entity = SyncEntities.TRIP,
-                id = tripId,
-                payload = SyncTripCreatePayload(
-                    title = request.title,
-                    description = request.description,
-                    startDate = request.startDate,
-                    endDate = request.endDate,
-                    locationLine = request.locationLine,
-                    coverUrl = request.coverUrl,
-                    currencyCode = request.currencyCode,
-                    days = days,
-                )
-            )
-            tripId
+        val trip = api.createTrip(request)
+        safeLocalMutation("createTrip.upsertTrip(tripId=${trip.id})") {
+            tripsCacheStore.upsertTrip(trip)
         }
+        return trip.id
     }
 
     override suspend fun updateTrip(tripId: String, request: UpdateTripRequest): Result<Unit> {
@@ -234,40 +191,4 @@ class TripRepositoryImpl @Inject constructor(
             tripMembersCacheStore.removeMember(tripId, memberId)
         }
     }
-}
-
-private fun buildLocalDays(
-    startDateRaw: String,
-    endDateRaw: String,
-): List<SyncTripCreateDayPayload> {
-    val startDate = LocalDate.parse(startDateRaw)
-    val endDate = LocalDate.parse(endDateRaw)
-    val result = mutableListOf<SyncTripCreateDayPayload>()
-    var current = startDate
-    var dayNumber = 1
-    while (!current.isAfter(endDate)) {
-        result += SyncTripCreateDayPayload(
-            id = UUID.randomUUID().toString(),
-            date = current.toString(),
-            dayNumber = dayNumber,
-        )
-        current = current.plusDays(1)
-        dayNumber += 1
-    }
-    return result
-}
-
-private fun SyncTripCreateDayPayload.toDayDto(tripId: String): ItineraryDayDto {
-    return ItineraryDayDto(
-        id = id,
-        tripId = tripId,
-        date = date,
-        dayNumber = dayNumber,
-        city = null,
-        cityProviderId = null,
-        cityLat = null,
-        cityLon = null,
-        isOutOfRange = false,
-        activities = emptyList(),
-    )
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsEvent.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsEvent.kt
@@ -2,6 +2,7 @@ package nvk.cotrip.ui.activity.details
 
 sealed interface ActivityDetailsEvent {
     data object OnBackClick : ActivityDetailsEvent
+    data object OnAutoRefresh : ActivityDetailsEvent
     data object OnRefresh : ActivityDetailsEvent
     data object OnEditClick : ActivityDetailsEvent
     data object OnOpenLinkClick : ActivityDetailsEvent

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsScreen.kt
@@ -72,7 +72,7 @@ fun ActivityDetailsScreen(
     DisposableEffect(lifecycleOwner, viewModel) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.onEvent(ActivityDetailsEvent.OnRefresh)
+                viewModel.onEvent(ActivityDetailsEvent.OnAutoRefresh)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
@@ -62,6 +62,7 @@ class ActivityDetailsViewModel @Inject constructor(
     fun onEvent(event: ActivityDetailsEvent) {
         when (event) {
             ActivityDetailsEvent.OnBackClick -> appNavigator.popBackStack()
+            ActivityDetailsEvent.OnAutoRefresh -> refreshActivity(showErrorToast = false)
             ActivityDetailsEvent.OnRefresh -> refreshActivity(showErrorToast = true)
             ActivityDetailsEvent.OnEditClick -> {
                 val contentState = _state.value as? ActivityDetailsState.Content ?: return

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/details/ActivityDetailsViewModel.kt
@@ -22,6 +22,7 @@ import nvk.cotrip.data.network.dto.ActivityDto
 import nvk.cotrip.data.network.dto.ItineraryDayDto
 import nvk.cotrip.data.network.dto.TripDto
 import nvk.cotrip.data.repository.ItineraryRepository
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.repository.TripRepository
 import nvk.cotrip.ui.common.UiErrorMapper
 import nvk.cotrip.ui.common.appUiLocale
@@ -134,7 +135,14 @@ class ActivityDetailsViewModel @Inject constructor(
                     appNavigator.popBackStack()
                 }
 
-                is ApiResult.Failure -> emitToast(uiErrorMapper.messageRes(result))
+                is ApiResult.Failure -> {
+                    val res = if (result.cause is OfflineWriteQueuedException) {
+                        R.string.common_error_network
+                    } else {
+                        uiErrorMapper.messageRes(result)
+                    }
+                    emitToast(res)
+                }
             }
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/activity/form/EditActivityViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/activity/form/EditActivityViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.ApiResult
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.network.dto.ActivityDto
 import nvk.cotrip.data.network.dto.ItineraryDayDto
 import nvk.cotrip.data.network.dto.MoveActivityRequest
@@ -212,7 +213,11 @@ class EditActivityViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(ActivityFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(ActivityFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(ActivityFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                     _state.update { it.copy(isSaving = false) }
                 }
             }
@@ -288,7 +293,11 @@ class EditActivityViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(ActivityFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(ActivityFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(ActivityFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -211,6 +213,7 @@ fun BuildRouteScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun HintCard() {
     Surface(
@@ -238,13 +241,6 @@ private fun HintCard() {
                     color = HintPurpleText
                 )
             }
-
-            Text(
-                text = stringResource(R.string.ai_suggestions_disclaimer),
-                style = MaterialTheme.typography.bodyMedium,
-                color = HintPurpleText,
-                fontWeight = FontWeight.Medium
-            )
         }
     }
 }
@@ -317,6 +313,7 @@ private fun CitySelector(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun OptionSection(
     title: String,
@@ -330,18 +327,17 @@ private fun OptionSection(
             color = TextSecondary
         )
 
-        options.chunked(4).forEach { rowOptions ->
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1),
-                modifier = Modifier.padding(bottom = CoTripTokens.spacing.x1)
-            ) {
-                rowOptions.forEach { option ->
-                    PreferenceChip(
-                        text = option.label,
-                        selected = option.selected,
-                        onClick = { onClick(option.label) }
-                    )
-                }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1),
+            verticalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1),
+        ) {
+            options.forEach { option ->
+                PreferenceChip(
+                    text = option.label,
+                    selected = option.selected,
+                    onClick = { onClick(option.label) }
+                )
             }
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -257,6 +259,7 @@ private fun SummaryHeader(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SuggestionCard(
     suggestion: AiSuggestionItemUi,
@@ -285,9 +288,10 @@ private fun SuggestionCard(
 
         Spacer(Modifier.height(CoTripTokens.spacing.x1_5))
 
-        Row(
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1),
         ) {
             MetaChip(icon = CoTripIcons.Info, text = suggestion.typeLabel)
             MetaChip(icon = CoTripIcons.Schedule, text = suggestion.durationLabel)

--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/RouteSuggestionsScreen.kt
@@ -1,6 +1,5 @@
 package nvk.cotrip.ui.aisuggestions
 
-import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -39,11 +39,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import nvk.cotrip.R
+import nvk.cotrip.ui.common.showCoTripToast
 import nvk.cotrip.ui.components.CoTripCard
 import nvk.cotrip.ui.components.CoTripIconButton
 import nvk.cotrip.ui.components.PrimaryButton
@@ -56,7 +58,12 @@ import nvk.cotrip.ui.theme.TextPrimary
 import nvk.cotrip.ui.theme.TextSecondary
 
 private const val KEY_HEADER = "header"
+private const val KEY_DISCLAIMER = "disclaimer"
 private const val KEY_BOTTOM_SPACER = "bottom_spacer"
+
+private val DisclaimerPurple = Color(0xFFEEDCF7)
+private val DisclaimerPurpleBorder = Color(0xFFD5B8E6)
+private val DisclaimerPurpleText = Color(0xFF6A1B9A)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,7 +77,7 @@ fun RouteSuggestionsScreen(
         viewModel.effects.collectLatest { effect ->
             when (effect) {
                 is RouteSuggestionsEffect.ShowToastRes ->
-                    Toast.makeText(context, context.getString(effect.resId), Toast.LENGTH_SHORT).show()
+                    context.showCoTripToast(effect.resId)
             }
         }
     }
@@ -133,6 +140,10 @@ fun RouteSuggestionsScreen(
                         )
                     }
 
+                    item(key = KEY_DISCLAIMER) {
+                        AiDisclaimerCard()
+                    }
+
                     items(uiState.suggestions, key = { it.id }) { suggestion ->
                         SuggestionCard(
                             suggestion = suggestion,
@@ -173,10 +184,35 @@ private fun LoadingState(modifier: Modifier = Modifier) {
                 style = MaterialTheme.typography.headlineSmall,
                 color = TextSecondary
             )
+        }
+    }
+}
+
+@Composable
+private fun AiDisclaimerCard() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = CoTripTokens.spacing.x2),
+        shape = RoundedCornerShape(18.dp),
+        border = BorderStroke(1.dp, DisclaimerPurpleBorder),
+        color = DisclaimerPurple
+    ) {
+        Row(
+            modifier = Modifier.padding(CoTripTokens.spacing.x2),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(CoTripTokens.spacing.x1)
+        ) {
+            Text(
+                text = stringResource(R.string.ai_suggestions_hint_symbol),
+                style = MaterialTheme.typography.headlineSmall,
+                color = DisclaimerPurpleText
+            )
             Text(
                 text = stringResource(R.string.ai_suggestions_disclaimer),
                 style = MaterialTheme.typography.bodyMedium,
-                color = TextSecondary
+                color = DisclaimerPurpleText,
+                fontWeight = FontWeight.Medium
             )
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/common/CoTripToast.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/common/CoTripToast.kt
@@ -1,0 +1,9 @@
+package nvk.cotrip.ui.common
+
+import android.content.Context
+import android.widget.Toast
+import androidx.annotation.StringRes
+
+fun Context.showCoTripToast(@StringRes resId: Int) {
+    Toast.makeText(this, getString(resId), Toast.LENGTH_LONG).show()
+}

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/details/ExpenseDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/details/ExpenseDetailsViewModel.kt
@@ -23,6 +23,7 @@ import nvk.cotrip.data.network.dto.ExpenseUpdateRequest
 import nvk.cotrip.data.network.dto.MemberDto
 import nvk.cotrip.data.network.dto.TripDto
 import nvk.cotrip.data.repository.ExpenseRepository
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.repository.TripRepository
 import nvk.cotrip.data.repository.UserRepository
 import nvk.cotrip.ui.common.UiErrorMapper
@@ -194,7 +195,15 @@ class ExpenseDetailsViewModel @Inject constructor(
             }) {
                 is ApiResult.Success -> refreshExpense(showErrorToast = false)
                 is ApiResult.Failure -> {
-                    _effects.emit(ExpenseDetailsEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    val res = if (result.cause is OfflineWriteQueuedException) {
+                        R.string.common_error_network
+                    } else {
+                        uiErrorMapper.messageRes(result)
+                    }
+                    _effects.emit(ExpenseDetailsEffect.ShowToastRes(res))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        refreshExpense(showErrorToast = false)
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/form/EditExpenseViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/form/EditExpenseViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.ApiResult
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.network.dto.ExpenseDto
 import nvk.cotrip.data.network.dto.ExpenseParticipantInput
 import nvk.cotrip.data.network.dto.ExpenseUpdateRequest
@@ -235,7 +236,11 @@ class EditExpenseViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(ExpenseFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(ExpenseFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(ExpenseFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                     _state.update { it.copy(isSaving = false) }
                 }
             }
@@ -252,7 +257,11 @@ class EditExpenseViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(ExpenseFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(ExpenseFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(ExpenseFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/expense/list/TripExpensesViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/expense/list/TripExpensesViewModel.kt
@@ -51,8 +51,6 @@ class TripExpensesViewModel @Inject constructor(
     private val _effects = MutableSharedFlow<TripExpensesEffect>(extraBufferCapacity = 8)
     val effects = _effects.asSharedFlow()
 
-    private val membersState = MutableStateFlow<List<MemberDto>>(emptyList())
-    private val meIdState = MutableStateFlow<String?>(null)
     private val isRefreshing = MutableStateFlow(false)
 
     init {
@@ -83,23 +81,23 @@ class TripExpensesViewModel @Inject constructor(
             combine(
                 expenseRepository.observeExpenses(tripId),
                 tripRepository.getTrip(tripId),
-                membersState,
-                meIdState,
+                tripRepository.tripMembers(tripId),
+                userRepository.me,
                 isRefreshing,
-            ) { expenses, trip, members, meId, refreshing ->
-                if (meId == null) {
-                    null
-                } else {
-                    ExpensesPayload(
-                        trip = trip,
-                        expenses = expenses,
-                        members = members,
-                        meId = meId,
-                        refreshing = refreshing,
-                    )
-                }
+            ) { expenses, trip, members, me, refreshing ->
+                ExpensesPayload(
+                    trip = trip,
+                    expenses = expenses,
+                    members = members,
+                    meId = me?.id,
+                    refreshing = refreshing,
+                )
             }.collect { payload ->
-                if (payload == null) return@collect
+                val meId = payload.meId
+                if (meId == null) {
+                    _state.value = TripExpensesState.Loading
+                    return@collect
+                }
                 val currencySymbol = currencySymbolFor(payload.trip.currencyCode)
                 val memberById = payload.members.associateBy { it.userId }
                 var totalSpent = 0.0
@@ -111,11 +109,11 @@ class TripExpensesViewModel @Inject constructor(
 
                 payload.expenses.forEach { expense ->
                     val shares = computeShares(expense)
-                    val myShare = shares[payload.meId] ?: 0.0
+                    val myShare = shares[meId] ?: 0.0
 
                     if (expense.status == "paid") {
                         totalSpent += expense.amount
-                        if (expense.paidById == payload.meId) {
+                        if (expense.paidById == meId) {
                             netBalance += (expense.amount - myShare)
                         } else {
                             netBalance -= myShare
@@ -127,7 +125,7 @@ class TripExpensesViewModel @Inject constructor(
                     val listItem = expense.toListItem(
                         currencySymbol = currencySymbol,
                         memberById = memberById,
-                        meId = payload.meId,
+                        meId = meId,
                         shares = shares,
                         context = appContext,
                     )
@@ -172,10 +170,6 @@ class TripExpensesViewModel @Inject constructor(
             when (val result = apiCaller.call {
                 tripRepository.getTrip(tripId).first()
                 expenseRepository.refreshExpenses(tripId).getOrThrow()
-                val members = tripRepository.tripMembers(tripId).first()
-                val me = checkNotNull(userRepository.me.first())
-                membersState.value = members
-                meIdState.value = me.id
             }) {
                 is ApiResult.Success -> Unit
                 is ApiResult.Failure -> {
@@ -192,7 +186,7 @@ class TripExpensesViewModel @Inject constructor(
         val trip: TripDto,
         val expenses: List<ExpenseDto>,
         val members: List<MemberDto>,
-        val meId: String,
+        val meId: String?,
         val refreshing: Boolean,
     )
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastScreen.kt
@@ -1,6 +1,5 @@
 package nvk.cotrip.ui.forecast
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -49,6 +48,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.flow.collectLatest
 import nvk.cotrip.R
+import nvk.cotrip.ui.common.showCoTripToast
 import nvk.cotrip.ui.components.CoTripCard
 import nvk.cotrip.ui.components.CoTripIconButton
 import nvk.cotrip.ui.components.CoTripListItem
@@ -85,8 +85,7 @@ fun TripForecastScreen(
         viewModel.effects.collectLatest { effect ->
             when (effect) {
                 is TripForecastEffect.ShowToastRes ->
-                    Toast.makeText(context, context.getString(effect.resId), Toast.LENGTH_SHORT)
-                        .show()
+                    context.showCoTripToast(effect.resId)
             }
         }
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastState.kt
@@ -4,7 +4,10 @@ sealed interface TripForecastState {
     data object Loading : TripForecastState
 
     data class Content(
+        /** Label shown in the UI (may be localized via `displayCity` from API). */
         val city: String,
+        /** City string used for weather cache/API requests (itinerary key). */
+        val weatherCityKey: String,
         val cityOptions: List<String> = emptyList(),
         val isCityPickerVisible: Boolean = false,
         val days: List<ForecastDayUi>,

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastUiMapper.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastUiMapper.kt
@@ -89,15 +89,19 @@ object TripForecastUiMapper {
             else -> context.getString(R.string.common_empty_placeholder)
         }
 
+        val localized = WeatherDescriptionMapper.localize(context, description)
+            ?: description
+        val descriptionText = localized?.replaceFirstChar { char ->
+            if (char.isLowerCase()) char.titlecase(appUiLocale()) else char.toString()
+        } ?: context.getString(R.string.trip_forecast_description_missing)
+
         return ForecastDayUi(
             title = title,
             subtitle = subtitle,
             icon = icon,
             iconTint = tint,
             temp = tempText,
-            description = description?.replaceFirstChar { char ->
-                if (char.isLowerCase()) char.titlecase(appUiLocale()) else char.toString()
-            } ?: context.getString(R.string.trip_forecast_description_missing),
+            description = descriptionText,
         )
     }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
@@ -22,6 +22,7 @@ import nvk.cotrip.data.repository.WeatherRepository
 import nvk.cotrip.ui.common.UiErrorMapper
 import nvk.cotrip.ui.navigation.AppNavigator
 import nvk.cotrip.ui.navigation.Destination
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -46,7 +47,10 @@ class TripForecastViewModel @Inject constructor(
     val effects = _effects.asSharedFlow()
 
     init {
-        refreshForecast(isUserRefresh = false, forceRefresh = true, showErrorToast = false)
+        viewModelScope.launch {
+            bootstrapFromCache()
+            refreshForecast(isUserRefresh = false, forceRefresh = true, showErrorToast = false)
+        }
     }
 
     fun onEvent(event: TripForecastEvent) {
@@ -76,6 +80,7 @@ class TripForecastViewModel @Inject constructor(
                 val current = _state.value as? TripForecastState.Content ?: return
                 _state.value = current.copy(
                     city = event.city,
+                    weatherCityKey = event.city,
                     isCityPickerVisible = false,
                 )
                 refreshForecast(
@@ -85,6 +90,49 @@ class TripForecastViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    private suspend fun bootstrapFromCache() {
+        val trip = tripRepository.getTrip(tripId).first()
+        val itinerary = itineraryRepository.getItinerary(tripId).first()
+        val cityOptions = collectCityOptions(itinerary)
+        val selectedCity = selectCity(itinerary, preferredWeatherCityKey = null)
+        if (selectedCity == null) {
+            _state.value = TripForecastState.Content(
+                city = "",
+                weatherCityKey = "",
+                cityOptions = cityOptions,
+                isCityPickerVisible = false,
+                days = emptyList(),
+                source = TripForecastUiMapper.source(appContext, WeatherForecastResponseDto()),
+                lastUpdated = "",
+                coverageMessage = TripForecastUiMapper.coverageMessage(
+                    context = appContext,
+                    hasSelectedCity = false,
+                    response = WeatherForecastResponseDto(),
+                ),
+                isRefreshing = false,
+            )
+            return
+        }
+
+        val cached = weatherRepository.getCachedWeather(
+            tripId = tripId,
+            city = selectedCity.city,
+            start = trip.startDate,
+            end = trip.endDate,
+        ) ?: WeatherForecastResponseDto(items = emptyList())
+        val cityLabel = cached.displayCity?.takeIf { it.isNotBlank() } ?: selectedCity.city
+        applyLoaded(
+            WeatherLoadResult(
+                weatherCityKey = selectedCity.city,
+                cityLabel = cityLabel,
+                cityOptions = cityOptions,
+                response = cached,
+                hasSelectedCity = true,
+            ),
+            isRefreshing = false,
+        )
     }
 
     private fun refreshForecast(
@@ -102,13 +150,15 @@ class TripForecastViewModel @Inject constructor(
 
             val result = apiCaller.call {
                 val trip = tripRepository.getTrip(tripId).first()
-                itineraryRepository.refreshItinerary(tripId).getOrThrow()
+                runCatching { itineraryRepository.refreshItinerary(tripId) }
                 val itinerary = itineraryRepository.getItinerary(tripId).first()
                 val cityOptions = collectCityOptions(itinerary)
-                val selectedCity = selectCity(itinerary, current?.city)
+                val preferredKey = current?.weatherCityKey?.trim()?.takeIf { it.isNotEmpty() }
+                val selectedCity = selectCity(itinerary, preferredKey)
                 if (selectedCity == null) {
                     WeatherLoadResult(
-                        city = "",
+                        weatherCityKey = "",
+                        cityLabel = "",
                         cityOptions = cityOptions,
                         response = WeatherForecastResponseDto(items = emptyList()),
                         hasSelectedCity = false,
@@ -119,23 +169,35 @@ class TripForecastViewModel @Inject constructor(
                             isUserRefresh ||
                             current == null ||
                             current.days.isEmpty() ||
-                            !current.city.equals(selectedCity.city, ignoreCase = true)
+                            current.weatherCityKey.isBlank() ||
+                            !current.weatherCityKey.equals(selectedCity.city, ignoreCase = true)
                     if (shouldRefresh) {
-                        weatherRepository.refreshWeather(
+                        val refreshResult = weatherRepository.refreshWeather(
                             tripId = tripId,
                             city = selectedCity.city,
                             start = trip.startDate,
                             end = trip.endDate,
-                        ).getOrThrow()
+                        )
+                        if (refreshResult.isFailure && isUserRefresh) {
+                            throw refreshResult.exceptionOrNull()
+                                ?: IOException("Weather refresh failed")
+                        }
                     }
-                    val response = weatherRepository.getWeather(
+                    val response = weatherRepository.getCachedWeather(
+                        tripId = tripId,
+                        city = selectedCity.city,
+                        start = trip.startDate,
+                        end = trip.endDate,
+                    ) ?: weatherRepository.getWeather(
                         tripId = tripId,
                         city = selectedCity.city,
                         start = trip.startDate,
                         end = trip.endDate,
                     ).first()
+                    val cityLabel = response.displayCity?.takeIf { it.isNotBlank() } ?: selectedCity.city
                     WeatherLoadResult(
-                        city = selectedCity.city,
+                        weatherCityKey = selectedCity.city,
+                        cityLabel = cityLabel,
                         cityOptions = cityOptions,
                         response = response,
                         hasSelectedCity = true,
@@ -145,25 +207,7 @@ class TripForecastViewModel @Inject constructor(
 
             when (result) {
                 is ApiResult.Success -> {
-                    val loaded = result.data
-                    val mappedDays = TripForecastUiMapper.mapDays(appContext, loaded.response)
-                    val source = TripForecastUiMapper.source(appContext, loaded.response)
-                    val lastUpdated = TripForecastUiMapper.lastUpdated(loaded.response)
-
-                    _state.value = TripForecastState.Content(
-                        city = loaded.city,
-                        cityOptions = loaded.cityOptions,
-                        isCityPickerVisible = false,
-                        days = mappedDays,
-                        source = source,
-                        lastUpdated = lastUpdated,
-                        coverageMessage = TripForecastUiMapper.coverageMessage(
-                            context = appContext,
-                            hasSelectedCity = loaded.hasSelectedCity,
-                            response = loaded.response,
-                        ),
-                        isRefreshing = false,
-                    )
+                    applyLoaded(result.data, isRefreshing = false)
                 }
 
                 is ApiResult.Failure -> {
@@ -179,6 +223,28 @@ class TripForecastViewModel @Inject constructor(
         }
     }
 
+    private fun applyLoaded(loaded: WeatherLoadResult, isRefreshing: Boolean) {
+        val mappedDays = TripForecastUiMapper.mapDays(appContext, loaded.response)
+        val source = TripForecastUiMapper.source(appContext, loaded.response)
+        val lastUpdated = TripForecastUiMapper.lastUpdated(loaded.response)
+
+        _state.value = TripForecastState.Content(
+            city = loaded.cityLabel,
+            weatherCityKey = loaded.weatherCityKey,
+            cityOptions = loaded.cityOptions,
+            isCityPickerVisible = false,
+            days = mappedDays,
+            source = source,
+            lastUpdated = lastUpdated,
+            coverageMessage = TripForecastUiMapper.coverageMessage(
+                context = appContext,
+                hasSelectedCity = loaded.hasSelectedCity,
+                response = loaded.response,
+            ),
+            isRefreshing = isRefreshing,
+        )
+    }
+
     private fun selectCity(days: List<ItineraryDayDto>): SelectedCity? {
         return days
             .sortedBy { it.dayNumber }
@@ -190,9 +256,9 @@ class TripForecastViewModel @Inject constructor(
 
     private fun selectCity(
         days: List<ItineraryDayDto>,
-        preferredCity: String?,
+        preferredWeatherCityKey: String?,
     ): SelectedCity? {
-        val normalizedPreferred = preferredCity?.trim()?.takeIf { it.isNotEmpty() }
+        val normalizedPreferred = preferredWeatherCityKey?.trim()?.takeIf { it.isNotEmpty() }
         val sorted = days.sortedBy { it.dayNumber }
         if (normalizedPreferred != null) {
             val preferredDay = sorted.firstOrNull { day ->
@@ -227,7 +293,8 @@ class TripForecastViewModel @Inject constructor(
     )
 
     private data class WeatherLoadResult(
-        val city: String,
+        val weatherCityKey: String,
+        val cityLabel: String,
         val cityOptions: List<String>,
         val response: WeatherForecastResponseDto,
         val hasSelectedCity: Boolean,

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/WeatherDescriptionMapper.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/WeatherDescriptionMapper.kt
@@ -1,0 +1,55 @@
+package nvk.cotrip.ui.forecast
+
+import android.content.Context
+import nvk.cotrip.R
+
+/**
+ * Localizes known OpenWeather English description strings client-side so cached English payloads
+ * still render correctly after locale or backend changes.
+ */
+object WeatherDescriptionMapper {
+    fun localize(context: Context, raw: String?): String? {
+        val text = raw?.trim()?.lowercase() ?: return null
+        if (text.isEmpty()) return null
+        val resId = when {
+            text == "clear sky" || text == "clear" -> R.string.weather_desc_clear
+            text == "few clouds" -> R.string.weather_desc_few_clouds
+            text == "scattered clouds" -> R.string.weather_desc_scattered_clouds
+            text == "broken clouds" || text == "overcast clouds" || text == "overcast" ->
+                R.string.weather_desc_broken_clouds
+
+            text == "mist" || text == "fog" -> R.string.weather_desc_mist
+            text == "smoke" || text == "haze" -> R.string.weather_desc_haze
+            text == "sand/dust whirls" || text == "dust" -> R.string.weather_desc_dust
+            text == "volcanic ash" -> R.string.weather_desc_volcanic_ash
+            text == "squalls" -> R.string.weather_desc_squalls
+            text == "tornado" -> R.string.weather_desc_tornado
+
+            text.startsWith("light rain") || text == "light intensity drizzle" ||
+                text == "drizzle" || text == "light intensity drizzle rain" ->
+                R.string.weather_desc_light_rain
+
+            text.startsWith("moderate rain") || text == "rain" ->
+                R.string.weather_desc_moderate_rain
+
+            text.startsWith("heavy rain") || text == "heavy intensity rain" ||
+                text == "very heavy rain" || text == "extreme rain" ->
+                R.string.weather_desc_heavy_rain
+
+            text.startsWith("freezing rain") -> R.string.weather_desc_freezing_rain
+            text.startsWith("light snow") || text == "snow" -> R.string.weather_desc_light_snow
+            text.startsWith("heavy snow") || text == "snowfall" -> R.string.weather_desc_heavy_snow
+            text.startsWith("sleet") || text == "shower sleet" -> R.string.weather_desc_sleet
+
+            text.startsWith("thunderstorm") || text.contains("thunderstorm with") ->
+                R.string.weather_desc_thunderstorm
+
+            text.startsWith("shower rain") -> R.string.weather_desc_shower_rain
+            text.startsWith("light shower snow") || text.startsWith("shower snow") ->
+                R.string.weather_desc_shower_snow
+
+            else -> null
+        }
+        return if (resId != null) context.getString(resId) else raw
+    }
+}

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsEvent.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsEvent.kt
@@ -4,6 +4,9 @@ import nvk.cotrip.ui.idea.common.IdeaDayOptionUi
 
 sealed interface IdeaDetailsEvent {
     data object OnBackClick : IdeaDetailsEvent
+    /** Lifecycle / silent refresh: no error toast when network fails but cache is shown. */
+    data object OnAutoRefresh : IdeaDetailsEvent
+    /** Explicit user refresh (e.g. pull-to-refresh): may show error toast. */
     data object OnRefresh : IdeaDetailsEvent
     data object OnEditClick : IdeaDetailsEvent
     data object OnAddToItineraryClick : IdeaDetailsEvent

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsScreen.kt
@@ -96,7 +96,7 @@ fun IdeaDetailsScreen(
     DisposableEffect(lifecycleOwner, viewModel) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.onEvent(IdeaDetailsEvent.OnRefresh)
+                viewModel.onEvent(IdeaDetailsEvent.OnAutoRefresh)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
@@ -40,6 +40,7 @@ import nvk.cotrip.data.network.ws.CommentEventsSourceFactory
 import nvk.cotrip.data.network.ws.CommentRejectedPayload
 import nvk.cotrip.data.network.ws.CommentWsEvent
 import nvk.cotrip.data.repository.IdeaRepository
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.repository.ItineraryRepository
 import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.data.repository.NotificationRepository
@@ -150,6 +151,7 @@ class IdeaDetailsViewModel @Inject constructor(
     fun onEvent(event: IdeaDetailsEvent) {
         when (event) {
             IdeaDetailsEvent.OnBackClick -> appNavigator.popBackStack()
+            IdeaDetailsEvent.OnAutoRefresh -> refreshDetails(showErrorToast = false)
             IdeaDetailsEvent.OnRefresh -> refreshDetails(showErrorToast = true)
             IdeaDetailsEvent.OnEditClick -> appNavigator.navigate(
                 Destination.EditIdea(tripId, ideaId)
@@ -637,7 +639,12 @@ class IdeaDetailsViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(IdeaDetailsEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    val res = if (result.cause is OfflineWriteQueuedException) {
+                        R.string.common_error_network
+                    } else {
+                        uiErrorMapper.messageRes(result)
+                    }
+                    emit(IdeaDetailsEffect.ShowToastRes(res))
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModel.kt
@@ -41,6 +41,7 @@ import nvk.cotrip.data.network.ws.CommentRejectedPayload
 import nvk.cotrip.data.network.ws.CommentWsEvent
 import nvk.cotrip.data.repository.IdeaRepository
 import nvk.cotrip.data.repository.ItineraryRepository
+import nvk.cotrip.data.network.NetworkStateProvider
 import nvk.cotrip.data.repository.NotificationRepository
 import nvk.cotrip.data.repository.TripRepository
 import nvk.cotrip.data.repository.UserRepository
@@ -79,6 +80,7 @@ class IdeaDetailsViewModel @Inject constructor(
     private val json: Json,
     private val apiCaller: ApiCaller,
     private val uiErrorMapper: UiErrorMapper,
+    private val networkStateProvider: NetworkStateProvider,
 ) : ViewModel() {
 
     private val tripId: String =
@@ -226,7 +228,7 @@ class IdeaDetailsViewModel @Inject constructor(
                 dayOptions = payload.itinerary.filter { !it.isOutOfRange }.map { it.toDayOption() }
                 val serverDiscussion = payload.comments
                     .sortedByDescending { parseTimestamp(it.createdAt)?.toEpochMilli() ?: 0L }
-                    .map { it.toDiscussion(meId, membersById, unknownMemberName) }
+                    .map { it.toDiscussion(appContext, meId, membersById, unknownMemberName) }
                 val discussion = mergeDiscussionWithPending(
                     serverDiscussion = serverDiscussion,
                     pending = pendingComments.values.toList(),
@@ -234,8 +236,11 @@ class IdeaDetailsViewModel @Inject constructor(
                     membersById = membersById,
                     youFallback = youName,
                 )
-                val isDiscussionAvailable = payload.comments.isNotEmpty() ||
-                    payload.membersById.isNotEmpty()
+                val memberCount = payload.membersById.size
+                val historyFromServer = payload.idea.hasHumanCommentHistory
+                val hasHumanComments = historyFromServer
+                    ?: payload.comments.any { it.type.equals("user", ignoreCase = true) }
+                val isDiscussionAvailable = memberCount > 1 || hasHumanComments
                 _state.update { current ->
                     current.copy(
                         title = payload.idea.title,
@@ -346,7 +351,7 @@ class IdeaDetailsViewModel @Inject constructor(
         _state.update { current ->
             val exists = current.discussion.any { item -> item.id == payload.id }
             if (exists) return@update current
-            val message = payload.toDiscussionItem(meId, membersById, unknownMemberName)
+            val message = payload.toDiscussionItem(appContext, meId, membersById, unknownMemberName)
             val increment = if (message is IdeaDiscussionItemUi.Message) 1 else 0
             val withoutLocal = if (resolvedLocalId != null) {
                 current.discussion.filterNot { item ->
@@ -402,6 +407,10 @@ class IdeaDetailsViewModel @Inject constructor(
 
     private fun selectDay(day: IdeaDayOptionUi) {
         _state.update { it.copy(dayPicker = null) }
+        if (!networkStateProvider.isOnline()) {
+            emit(IdeaDetailsEffect.ShowToastRes(R.string.common_error_server_unreachable))
+            return
+        }
         viewModelScope.launch {
             when (val result = apiCaller.call {
                 ideaRepository.convertIdeaToActivity(ideaId, ConvertIdeaRequest(dayId = day.id))
@@ -422,6 +431,10 @@ class IdeaDetailsViewModel @Inject constructor(
         if (!_state.value.isDiscussionAvailable) return
         val input = _state.value.commentInput.trim()
         if (input.isBlank()) return
+        if (!networkStateProvider.isOnline()) {
+            emit(IdeaDetailsEffect.ShowToastRes(R.string.common_error_server_unreachable))
+            return
+        }
         val token = sessionStore.getAccessToken()
         if (token.isNullOrBlank()) {
             emit(IdeaDetailsEffect.ShowToastRes(R.string.common_error_message))
@@ -689,6 +702,7 @@ class IdeaDetailsViewModel @Inject constructor(
 }
 
 private fun CommentDto.toDiscussion(
+    context: Context,
     meId: String?,
     membersById: Map<String, MemberDto>,
     unknownNameFallback: String,
@@ -696,7 +710,7 @@ private fun CommentDto.toDiscussion(
     if (type.equals("system", ignoreCase = true)) {
         return IdeaDiscussionItemUi.System(
             id = id,
-            text = body,
+            text = localizedSystemText(context),
             time = formatTimestamp(createdAt),
         )
     }
@@ -718,6 +732,7 @@ private fun CommentDto.toDiscussion(
 }
 
 private fun CommentCreatedPayload.toDiscussion(
+    @Suppress("UNUSED_PARAMETER") context: Context,
     meId: String?,
     membersById: Map<String, MemberDto>,
     unknownNameFallback: String,
@@ -741,6 +756,7 @@ private fun CommentCreatedPayload.toDiscussion(
 }
 
 private fun CommentCreatedPayload.toDiscussionItem(
+    context: Context,
     meId: String?,
     membersById: Map<String, MemberDto>,
     unknownNameFallback: String,
@@ -748,11 +764,11 @@ private fun CommentCreatedPayload.toDiscussionItem(
     return if (type.equals("system", ignoreCase = true)) {
         IdeaDiscussionItemUi.System(
             id = id,
-            text = body,
+            text = this@toDiscussionItem.localizedSystemText(context),
             time = formatTimestamp(createdAt),
         )
     } else {
-        toDiscussion(meId, membersById, unknownNameFallback)
+        toDiscussion(context, meId, membersById, unknownNameFallback)
     }
 }
 

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaSystemCommentText.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/details/IdeaSystemCommentText.kt
@@ -1,0 +1,56 @@
+package nvk.cotrip.ui.idea.details
+
+import android.content.Context
+import nvk.cotrip.R
+import nvk.cotrip.data.network.dto.CommentDto
+import nvk.cotrip.data.network.ws.CommentCreatedPayload
+
+internal fun localizedSystemCommentText(
+    context: Context,
+    type: String,
+    body: String,
+    systemKey: String?,
+    systemActorName: String?,
+): String {
+    if (!type.equals("system", ignoreCase = true)) return body
+    val actor = systemActorName?.trim().orEmpty()
+    return when (systemKey) {
+        "idea_edited" -> context.getString(R.string.system_comment_idea_edited, actor)
+        "idea_added_to_itinerary" ->
+            context.getString(R.string.system_comment_idea_added_to_itinerary, actor)
+        else -> legacyEnglishSystemBody(context, body)
+    }
+}
+
+private fun legacyEnglishSystemBody(context: Context, body: String): String {
+    val edited = Regex("^(.+) edited the idea$").find(body.trim())
+    if (edited != null) {
+        return context.getString(R.string.system_comment_idea_edited, edited.groupValues[1].trim())
+    }
+    val added = Regex("^(.+) added this idea to the itinerary$").find(body.trim())
+    if (added != null) {
+        return context.getString(
+            R.string.system_comment_idea_added_to_itinerary,
+            added.groupValues[1].trim(),
+        )
+    }
+    return body
+}
+
+internal fun CommentDto.localizedSystemText(context: Context): String =
+    localizedSystemCommentText(
+        context = context,
+        type = type,
+        body = body,
+        systemKey = systemKey,
+        systemActorName = systemActorName,
+    )
+
+internal fun CommentCreatedPayload.localizedSystemText(context: Context): String =
+    localizedSystemCommentText(
+        context = context,
+        type = type,
+        body = body,
+        systemKey = systemKey,
+        systemActorName = systemActorName,
+    )

--- a/android/app/src/main/java/nvk/cotrip/ui/idea/form/EditIdeaViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/idea/form/EditIdeaViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import nvk.cotrip.R
 import nvk.cotrip.data.network.ApiCaller
 import nvk.cotrip.data.network.ApiResult
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.network.dto.UpdateIdeaRequest
 import nvk.cotrip.data.repository.IdeaRepository
 import nvk.cotrip.data.repository.ItineraryRepository
@@ -225,7 +226,11 @@ class EditIdeaViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(IdeaFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(IdeaFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(IdeaFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                     _state.update { it.copy(isSaving = false) }
                 }
             }
@@ -242,7 +247,11 @@ class EditIdeaViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emit(IdeaFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    if (result.cause is OfflineWriteQueuedException) {
+                        emit(IdeaFormEffect.ShowToastRes(R.string.common_error_network))
+                    } else {
+                        emit(IdeaFormEffect.ShowToastRes(uiErrorMapper.messageRes(result)))
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleEvent.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleEvent.kt
@@ -2,6 +2,7 @@ package nvk.cotrip.ui.invitation
 
 sealed interface InvitePeopleEvent {
     data object OnCloseClick : InvitePeopleEvent
+    data object OnRetryClick : InvitePeopleEvent
     data object OnCopyClick : InvitePeopleEvent
     data object OnShareClick : InvitePeopleEvent
 }

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleScreen.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleScreen.kt
@@ -120,6 +120,29 @@ fun InvitePeopleScreen(
                 }
             }
 
+            InvitePeopleState.Unavailable -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .padding(horizontal = CoTripTokens.spacing.x2),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = stringResource(R.string.invite_people_load_failed),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = TextMedium
+                    )
+                    Spacer(modifier = Modifier.height(CoTripTokens.spacing.x2))
+                    PrimaryButton(
+                        text = stringResource(R.string.invite_people_retry),
+                        onClick = { viewModel.onEvent(InvitePeopleEvent.OnRetryClick) },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+
             is InvitePeopleState.Content -> {
                 Column(
                     modifier = Modifier

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleState.kt
@@ -3,6 +3,8 @@ package nvk.cotrip.ui.invitation
 sealed interface InvitePeopleState {
     data object Loading : InvitePeopleState
 
+    data object Unavailable : InvitePeopleState
+
     data class Content(
         val tripId: String,
         val inviteLink: String,

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/InvitePeopleViewModel.kt
@@ -45,6 +45,7 @@ class InvitePeopleViewModel @Inject constructor(
     fun onEvent(event: InvitePeopleEvent) {
         when (event) {
             InvitePeopleEvent.OnCloseClick -> appNavigator.popBackStack()
+            InvitePeopleEvent.OnRetryClick -> loadInvite()
 
             InvitePeopleEvent.OnCopyClick -> {
                 val link = (_state.value as? InvitePeopleState.Content)?.inviteLink.orEmpty()
@@ -64,6 +65,7 @@ class InvitePeopleViewModel @Inject constructor(
 
     private fun loadInvite() {
         viewModelScope.launch {
+            _state.value = InvitePeopleState.Loading
             val result = apiCaller.call {
                 inviteRepository.createInvite(tripId)
             }
@@ -86,7 +88,7 @@ class InvitePeopleViewModel @Inject constructor(
                 }
 
                 is ApiResult.Failure -> {
-                    emitToast(uiErrorMapper.messageRes(result))
+                    _state.value = InvitePeopleState.Unavailable
                 }
             }
         }

--- a/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/invitation/JoinTripViewModel.kt
@@ -100,36 +100,28 @@ class JoinTripViewModel @Inject constructor(
 
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, inlineErrorRes = null) }
-            val preflight = apiCaller.call {
-                runCatching { tripRepository.refreshTrips() }
-                val joinedIds = tripRepository.trips.first().mapTo(mutableSetOf()) { it.id }
-                when (target) {
-                    is JoinTarget.InviteToken -> {
-                        val invite = inviteRepository.getInvite(target.token).first()
-                        joinedIds.contains(invite.tripId)
-                    }
-                    is JoinTarget.TripId -> joinedIds.contains(target.tripId)
-                }
-            }
-
-            when (preflight) {
-                is ApiResult.Success -> {
-                    if (preflight.data) {
-                        _state.update {
-                            it.copy(
-                                isLoading = false,
-                                inlineErrorRes = R.string.join_trip_already_joined,
-                            )
-                        }
+            runCatching { tripRepository.refreshTrips() }
+            val joinedIds = tripRepository.trips.first().mapTo(mutableSetOf()) { it.id }
+            val alreadyJoined = when (target) {
+                is JoinTarget.InviteToken -> {
+                    val invite = inviteRepository.getInviteForJoin(target.token)
+                    if (invite == null) {
+                        _state.update { it.copy(isLoading = false) }
+                        emit(JoinTripEffect.ShowToastRes(R.string.common_error_server_unreachable))
                         return@launch
                     }
+                    joinedIds.contains(invite.tripId)
                 }
-
-                is ApiResult.Failure -> {
-                    _state.update { it.copy(isLoading = false) }
-                    emit(JoinTripEffect.ShowToastRes(uiErrorMapper.messageRes(preflight)))
-                    return@launch
+                is JoinTarget.TripId -> joinedIds.contains(target.tripId)
+            }
+            if (alreadyJoined) {
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        inlineErrorRes = R.string.join_trip_already_joined,
+                    )
                 }
+                return@launch
             }
 
             val result = apiCaller.call {

--- a/android/app/src/main/java/nvk/cotrip/ui/trip/details/TripDetailsWeatherMapper.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/trip/details/TripDetailsWeatherMapper.kt
@@ -50,6 +50,7 @@ object TripDetailsWeatherMapper {
         response: WeatherForecastResponseDto,
         isCitySelectable: Boolean = false,
     ): WeatherCardUi {
+        val cityLabel = response.displayCity?.takeIf { it.isNotBlank() } ?: city
         val days = response.items
             .sortedBy { it.date }
             .take(5)
@@ -82,7 +83,7 @@ object TripDetailsWeatherMapper {
         }
 
         return WeatherCardUi(
-            city = city,
+            city = cityLabel,
             days = days,
             notice = notice,
             isCitySelectable = isCitySelectable,

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -185,6 +185,9 @@
     <string name="ideas_pick_day_title">Выберите день</string>
     <string name="ideas_pick_day_label">День %1$d · %2$s</string>
     <string name="ideas_empty_placeholder">Добавьте идеи для поездки или попросите AI предложить варианты.</string>
+    <string name="invite_people_load_failed">Не удалось загрузить ссылку-приглашение.</string>
+    <string name="invite_people_retry">Повторить</string>
+
     <string name="ideas_get_ai_suggestions">Получить AI-подсказки</string>
 
     <!--Idea Details-->
@@ -426,6 +429,30 @@
     <string name="trip_details_day_number">День %1$d</string>
 
     <!--Weather Forecast Extras-->
+    <string name="weather_desc_clear">Ясно</string>
+    <string name="weather_desc_few_clouds">Небольшая облачность</string>
+    <string name="weather_desc_scattered_clouds">Переменная облачность</string>
+    <string name="weather_desc_broken_clouds">Облачно</string>
+    <string name="weather_desc_mist">Туман</string>
+    <string name="weather_desc_haze">Дымка</string>
+    <string name="weather_desc_dust">Пыль</string>
+    <string name="weather_desc_volcanic_ash">Вулканический пепел</string>
+    <string name="weather_desc_squalls">Шквалы</string>
+    <string name="weather_desc_tornado">Торнадо</string>
+    <string name="weather_desc_light_rain">Небольшой дождь</string>
+    <string name="weather_desc_moderate_rain">Дождь</string>
+    <string name="weather_desc_heavy_rain">Сильный дождь</string>
+    <string name="weather_desc_freezing_rain">Ледяной дождь</string>
+    <string name="weather_desc_light_snow">Снег</string>
+    <string name="weather_desc_heavy_snow">Сильный снег</string>
+    <string name="weather_desc_sleet">Мокрый снег</string>
+    <string name="weather_desc_thunderstorm">Гроза</string>
+    <string name="weather_desc_shower_rain">Ливень</string>
+    <string name="weather_desc_shower_snow">Снегопад</string>
+
+    <string name="system_comment_idea_edited">%1$s отредактировал(а) идею</string>
+    <string name="system_comment_idea_added_to_itinerary">%1$s добавил(а) эту идею в маршрут</string>
+
     <string name="trip_forecast_source_default">OpenWeather</string>
     <string name="trip_forecast_coverage_city_missing">Сначала выберите город в маршруте, чтобы получить прогноз.</string>
     <string name="trip_forecast_coverage_unavailable">Прогноз на эти даты пока недоступен. OpenWeather предоставляет данные максимум на 8 ближайших дней.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -196,7 +196,7 @@
     <string name="idea_details_tab_discussion">Обсуждение</string>
     <string name="idea_details_city">Город</string>
     <string name="idea_details_link">Ссылка</string>
-    <string name="idea_details_cost">Оценка стоимости</string>
+    <string name="idea_details_cost">Примерная стоимость</string>
     <string name="idea_details_notes">Заметки</string>
     <string name="idea_details_add_to_itinerary">Добавить в маршрут</string>
     <string name="idea_details_added_to_day">Добавлено в день %1$d</string>
@@ -222,7 +222,7 @@
     <string name="idea_form_city_label">Место</string>
     <string name="idea_form_city_searching">Поиск по местам поездки...</string>
     <string name="idea_form_link_label">Ссылка (необязательно)</string>
-    <string name="idea_form_cost_label">Оценка стоимости</string>
+    <string name="idea_form_cost_label">Примерная стоимость</string>
     <string name="idea_form_notes_label">Заметки</string>
     <string name="idea_form_title_placeholder">Введите название идеи</string>
     <string name="idea_form_city_placeholder">Найдите место в истории поездки или введите текст</string>
@@ -256,7 +256,7 @@
     <string name="ai_suggestions_generate">Сгенерировать</string>
     <string name="ai_suggestions_change">Изменить</string>
     <string name="ai_suggestions_loading">Генерация подсказок...</string>
-    <string name="ai_suggestions_estimated_cost">Оценка стоимости: %1$s</string>
+    <string name="ai_suggestions_estimated_cost">Примерная стоимость: %1$s</string>
     <string name="ai_suggestions_save_to_ideas">Сохранить в идеи</string>
     <string name="ai_suggestions_saved">Сохранено</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -181,6 +181,9 @@
     <string name="ideas_pick_day_title">Select day</string>
     <string name="ideas_pick_day_label">Day %1$d · %2$s</string>
     <string name="ideas_empty_placeholder">Start adding ideas for your trip or ask AI for suggestions.</string>
+    <string name="invite_people_load_failed">Could not load invite link.</string>
+    <string name="invite_people_retry">Try again</string>
+
     <string name="ideas_get_ai_suggestions">Get AI suggestions</string>
 
     <!--Idea Details-->
@@ -419,6 +422,30 @@
     <string name="trip_details_day_number">Day %1$d</string>
 
     <!--Weather Forecast Extras-->
+    <string name="weather_desc_clear">Clear</string>
+    <string name="weather_desc_few_clouds">Few clouds</string>
+    <string name="weather_desc_scattered_clouds">Scattered clouds</string>
+    <string name="weather_desc_broken_clouds">Cloudy</string>
+    <string name="weather_desc_mist">Mist</string>
+    <string name="weather_desc_haze">Haze</string>
+    <string name="weather_desc_dust">Dust</string>
+    <string name="weather_desc_volcanic_ash">Volcanic ash</string>
+    <string name="weather_desc_squalls">Squalls</string>
+    <string name="weather_desc_tornado">Tornado</string>
+    <string name="weather_desc_light_rain">Light rain</string>
+    <string name="weather_desc_moderate_rain">Rain</string>
+    <string name="weather_desc_heavy_rain">Heavy rain</string>
+    <string name="weather_desc_freezing_rain">Freezing rain</string>
+    <string name="weather_desc_light_snow">Snow</string>
+    <string name="weather_desc_heavy_snow">Heavy snow</string>
+    <string name="weather_desc_sleet">Sleet</string>
+    <string name="weather_desc_thunderstorm">Thunderstorm</string>
+    <string name="weather_desc_shower_rain">Rain showers</string>
+    <string name="weather_desc_shower_snow">Snow showers</string>
+
+    <string name="system_comment_idea_edited">%1$s edited the idea</string>
+    <string name="system_comment_idea_added_to_itinerary">%1$s added this idea to the itinerary</string>
+
     <string name="trip_forecast_source_default">OpenWeather</string>
     <string name="trip_forecast_coverage_city_missing">Select a city in itinerary first to get weather.</string>
     <string name="trip_forecast_coverage_unavailable">Forecast is not available for these dates yet. OpenWeather provides up to 8 upcoming days.</string>

--- a/android/app/src/test/java/nvk/cotrip/data/network/AuthInterceptorTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/data/network/AuthInterceptorTest.kt
@@ -11,6 +11,7 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class AuthInterceptorTest {
@@ -28,8 +29,11 @@ class AuthInterceptorTest {
         interceptor.intercept(chain)
 
         // THEN
-        assertEquals(request, chain.proceededRequest)
         assertNull(chain.proceededRequest?.header("Authorization"))
+        assertEquals(
+            Locale.getDefault().toLanguageTag(),
+            chain.proceededRequest?.header("Accept-Language"),
+        )
     }
 
     @Test
@@ -45,8 +49,11 @@ class AuthInterceptorTest {
         interceptor.intercept(chain)
 
         // THEN
-        assertEquals(request, chain.proceededRequest)
         assertNull(chain.proceededRequest?.header("Authorization"))
+        assertEquals(
+            Locale.getDefault().toLanguageTag(),
+            chain.proceededRequest?.header("Accept-Language"),
+        )
     }
 
     @Test

--- a/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
@@ -46,6 +46,7 @@ import nvk.cotrip.data.network.dto.UpdateUserRequest
 import nvk.cotrip.data.network.dto.UserDto
 import nvk.cotrip.data.sync.CoTripDatabase
 import nvk.cotrip.data.sync.SyncEntities
+import nvk.cotrip.data.repository.OfflineWriteQueuedException
 import nvk.cotrip.data.sync.SyncQueueRepository
 import nvk.cotrip.data.sync.SyncScheduler
 import nvk.cotrip.notifications.PushTokenSyncManager
@@ -510,12 +511,15 @@ class OfflineCreateRepositoriesTest {
         )
 
         // WHEN
-        repository.updateExpense(
-            expenseId = "expense-1",
-            request = ExpenseUpdateRequest(title = "After"),
-        )
+        val thrown = runCatching {
+            repository.updateExpense(
+                expenseId = "expense-1",
+                request = ExpenseUpdateRequest(title = "After"),
+            )
+        }.exceptionOrNull()
 
         // THEN
+        assertTrue(thrown is OfflineWriteQueuedException)
         assertEquals("After", expensesStore.findExpenseById("expense-1")?.title)
         val pending = database.syncChangeDao().listPending(10)
         assertEquals(1, pending.size)

--- a/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/data/repository/OfflineCreateRepositoriesTest.kt
@@ -87,7 +87,7 @@ class OfflineCreateRepositoriesTest {
     }
 
     @Test
-    fun given_apiOffline_when_createTrip_then_createsLocalTripAndQueueItem() = runTest {
+    fun given_apiOffline_when_createTrip_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.createTrip(any()) } throws IOException("offline")
@@ -107,31 +107,27 @@ class OfflineCreateRepositoriesTest {
             networkStateProvider = networkStateProvider,
         )
 
-        // WHEN
-        val tripId = repository.createTrip(
-            CreateTripRequest(
-                title = "Offline Trip",
-                description = "desc",
-                startDate = "2026-06-10",
-                endDate = "2026-06-12",
-                locationLine = "Berlin",
-                coverUrl = null,
-                currencyCode = "EUR",
+        // WHEN / THEN
+        expectIOException {
+            repository.createTrip(
+                CreateTripRequest(
+                    title = "Offline Trip",
+                    description = "desc",
+                    startDate = "2026-06-10",
+                    endDate = "2026-06-12",
+                    locationLine = "Berlin",
+                    coverUrl = null,
+                    currencyCode = "EUR",
+                )
             )
-        )
-
-        // THEN
-        assertTrue(tripsStore.getTrips().any { it.id == tripId })
-        assertEquals(3, itineraryStore.getItinerary(tripId).size)
+        }
+        assertTrue(tripsStore.getTrips().isEmpty())
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.TRIP, pending.first().entity)
-        assertEquals("create", pending.first().type)
-        assertEquals(tripId, pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     @Test
-    fun given_apiOffline_when_createIdea_then_createsLocalIdeaAndQueueItem() = runTest {
+    fun given_apiOffline_when_createIdea_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.createIdea(any(), any()) } throws IOException("offline")
@@ -144,35 +140,31 @@ class OfflineCreateRepositoriesTest {
             syncQueueRepository = queue,
             ideasCacheStore = ideasStore,
             commentsCacheStore = FakeIdeaCommentsCacheStore(),
-            itineraryCacheStore = FakeItineraryCacheStore(),
             userCacheStore = userStore,
             networkStateProvider = networkStateProvider,
         )
 
-        // WHEN
-        val idea = repository.createIdea(
-            tripId = "trip-idea-1",
-            request = CreateIdeaRequest(
-                title = "Local idea",
-                city = "Paris",
-                link = null,
-                costAmount = 25.0,
-                costType = "per_person",
-                notes = "note",
+        // WHEN / THEN
+        expectIOException {
+            repository.createIdea(
+                tripId = "trip-idea-1",
+                request = CreateIdeaRequest(
+                    title = "Local idea",
+                    city = "Paris",
+                    link = null,
+                    costAmount = 25.0,
+                    costType = "per_person",
+                    notes = "note",
+                )
             )
-        )
-
-        // THEN
-        assertTrue(ideasStore.getIdeas("trip-idea-1").any { it.id == idea.id })
+        }
+        assertTrue(ideasStore.getIdeas("trip-idea-1").isEmpty())
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.IDEA, pending.first().entity)
-        assertEquals("create", pending.first().type)
-        assertEquals(idea.id, pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     @Test
-    fun given_apiOffline_when_createExpense_then_createsLocalExpenseAndQueueItem() = runTest {
+    fun given_apiOffline_when_createExpense_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.createExpense(any(), any()) } throws IOException("offline")
@@ -184,38 +176,35 @@ class OfflineCreateRepositoriesTest {
             networkStateProvider = networkStateProvider,
         )
 
-        // WHEN
-        val expense = repository.createExpense(
-            tripId = "trip-expense-1",
-            request = ExpenseCreateRequest(
-                title = "Taxi",
-                amount = 42.0,
-                currencyCode = "EUR",
-                status = "paid",
-                paidById = "user-1",
-                date = "2026-06-10",
-                splitType = "equally",
-                note = "airport",
-                participants = listOf(
-                    ExpenseParticipantInput(
-                        userId = "user-1",
-                        isIncluded = true
-                    )
-                ),
+        // WHEN / THEN
+        expectIOException {
+            repository.createExpense(
+                tripId = "trip-expense-1",
+                request = ExpenseCreateRequest(
+                    title = "Taxi",
+                    amount = 42.0,
+                    currencyCode = "EUR",
+                    status = "paid",
+                    paidById = "user-1",
+                    date = "2026-06-10",
+                    splitType = "equally",
+                    note = "airport",
+                    participants = listOf(
+                        ExpenseParticipantInput(
+                            userId = "user-1",
+                            isIncluded = true
+                        )
+                    ),
+                )
             )
-        )
-
-        // THEN
-        assertTrue(expensesStore.getExpenses("trip-expense-1").any { it.id == expense.id })
+        }
+        assertTrue(expensesStore.getExpenses("trip-expense-1").isEmpty())
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.EXPENSE, pending.first().entity)
-        assertEquals("create", pending.first().type)
-        assertEquals(expense.id, pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     @Test
-    fun given_apiOffline_when_createActivity_then_createsLocalActivityAndQueueItem() = runTest {
+    fun given_apiOffline_when_createActivity_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.createActivity(any(), any()) } throws IOException("offline")
@@ -254,25 +243,20 @@ class OfflineCreateRepositoriesTest {
             networkStateProvider = networkStateProvider,
         )
 
-        // WHEN
-        val created = repository.createActivity(
-            dayId = dayId,
-            request = CreateActivityRequest(
-                title = "Offline activity",
-                orderIndex = null,
+        // WHEN / THEN
+        expectIOException {
+            repository.createActivity(
+                dayId = dayId,
+                request = CreateActivityRequest(
+                    title = "Offline activity",
+                    orderIndex = null,
+                )
             )
-        )
-
-        // THEN
+        }
         val storedDay = itineraryStore.getItinerary(tripId).first { it.id == dayId }
-        assertTrue(storedDay.activities.any { it.id == created.id })
-        assertEquals(1, created.orderIndex)
-
+        assertEquals(1, storedDay.activities.size)
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.ACTIVITY, pending.first().entity)
-        assertEquals("create", pending.first().type)
-        assertEquals(created.id, pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     @Test
@@ -401,7 +385,6 @@ class OfflineCreateRepositoriesTest {
             syncQueueRepository = queue,
             ideasCacheStore = ideasStore,
             commentsCacheStore = FakeIdeaCommentsCacheStore(),
-            itineraryCacheStore = FakeItineraryCacheStore(),
             userCacheStore = FakeUserCacheStore(),
             networkStateProvider = networkStateProvider,
         )
@@ -423,7 +406,7 @@ class OfflineCreateRepositoriesTest {
     }
 
     @Test
-    fun given_apiOffline_when_convertIdea_then_updatesLocalItineraryAndQueuesConvertCommand() = runTest {
+    fun given_apiOffline_when_convertIdea_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.convertIdeaToActivity(any(), any()) } throws IOException("offline")
@@ -474,26 +457,21 @@ class OfflineCreateRepositoriesTest {
             syncQueueRepository = queue,
             ideasCacheStore = ideasStore,
             commentsCacheStore = FakeIdeaCommentsCacheStore(),
-            itineraryCacheStore = itineraryStore,
             userCacheStore = FakeUserCacheStore(),
             networkStateProvider = networkStateProvider,
         )
 
-        // WHEN
-        repository.convertIdeaToActivity(
-            ideaId = "idea-convert-1",
-            request = ConvertIdeaRequest(dayId = dayId),
-        )
-
-        // THEN
+        // WHEN / THEN
+        expectIOException {
+            repository.convertIdeaToActivity(
+                ideaId = "idea-convert-1",
+                request = ConvertIdeaRequest(dayId = dayId),
+            )
+        }
         val activities = itineraryStore.getItinerary(tripId).first { it.id == dayId }.activities
-        assertEquals(1, activities.size)
-        assertEquals("idea-convert-1", activities.first().sourceIdeaId)
+        assertTrue(activities.isEmpty())
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.IDEA_CONVERT, pending.first().entity)
-        assertEquals("create", pending.first().type)
-        assertEquals("idea-convert-1", pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     @Test
@@ -674,28 +652,30 @@ class OfflineCreateRepositoriesTest {
     }
 
     @Test
-    fun given_apiOffline_when_saveAiSuggestion_then_queuesSaveCommand() = runTest {
+    fun given_apiOffline_when_saveAiSuggestion_then_propagatesWithoutEnqueue() = runTest {
         // GIVEN
         val api = mockk<CoTripApi>()
         coEvery { api.saveAiSuggestionToIdeas(any()) } throws IOException("offline")
         val repository = AiSuggestionsRepositoryImpl(
             api = api,
-            syncQueueRepository = queue,
         )
 
-        // WHEN
-        repository.saveSuggestionToIdeas("suggestion-1")
-
-        // THEN
+        // WHEN / THEN
+        expectIOException {
+            repository.saveSuggestionToIdeas("suggestion-1")
+        }
         val pending = database.syncChangeDao().listPending(10)
-        assertEquals(1, pending.size)
-        assertEquals(SyncEntities.AI_SUGGESTION_SAVE, pending.first().entity)
-        assertEquals("upsert", pending.first().type)
-        assertEquals("suggestion-1", pending.first().entityId)
+        assertEquals(0, pending.size)
     }
 
     private class NoOpSyncScheduler(context: Context) : SyncScheduler(context) {
         override fun schedule() = Unit
+    }
+
+    private suspend fun expectIOException(block: suspend () -> Unit) {
+        val result = runCatching { block() }
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IOException)
     }
 }
 

--- a/android/app/src/test/java/nvk/cotrip/ui/forecast/TripForecastScreenComposeTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/forecast/TripForecastScreenComposeTest.kt
@@ -35,6 +35,7 @@ class TripForecastScreenComposeTest {
         val context: Context = ApplicationProvider.getApplicationContext()
         val weatherTitle = context.getString(R.string.weather_forecast_title)
         val pickerTitle = context.getString(R.string.itinerary_choose_city_title)
+        val clearSkyLabel = context.getString(R.string.weather_desc_clear)
         val viewModel = createViewModel(
             itineraryRepository = FakeItineraryRepository(
                 initial = listOf(
@@ -57,7 +58,7 @@ class TripForecastScreenComposeTest {
         // THEN
         composeRule.onNodeWithText(weatherTitle, substring = true).assertIsDisplayed()
         composeRule.onNodeWithText("Rome", substring = true).assertIsDisplayed()
-        composeRule.onNodeWithText("Clear sky", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText(clearSkyLabel, substring = true).assertIsDisplayed()
 
         // WHEN
         composeRule.onNodeWithText("Rome", substring = true).performClick()

--- a/android/app/src/test/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/idea/details/IdeaDetailsViewModelTest.kt
@@ -297,6 +297,9 @@ class IdeaDetailsViewModelTest {
             every { it.getAccessToken() } returns ""
         },
         commentEventsSourceFactory: FakeCommentEventsSourceFactory = FakeCommentEventsSourceFactory(),
+        networkStateProvider: NetworkStateProvider = mockk {
+            every { isOnline() } returns true
+        },
     ): IdeaDetailsViewModel {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
         return IdeaDetailsViewModel(
@@ -314,6 +317,7 @@ class IdeaDetailsViewModelTest {
             json = Json { ignoreUnknownKeys = true },
             apiCaller = apiCaller,
             uiErrorMapper = uiErrorMapper,
+            networkStateProvider = networkStateProvider,
         )
     }
 }

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleScreenComposeTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleScreenComposeTest.kt
@@ -151,6 +151,16 @@ class InvitePeopleScreenComposeTest {
             )
         )
 
+        override suspend fun getInviteForJoin(token: String): InviteInfoDto =
+            InviteInfoDto(
+                tripId = "trip",
+                title = "Trip",
+                startDate = "2026-01-10",
+                endDate = "2026-01-12",
+                locationLine = null,
+                expiresAt = "2026-12-31T00:00:00Z",
+            )
+
         override suspend fun acceptInvite(token: String): String = "trip"
 
         override suspend fun joinTripById(tripId: String): String = tripId

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/InvitePeopleViewModelTest.kt
@@ -174,7 +174,7 @@ class InvitePeopleViewModelTest {
     }
 
     @Test
-    fun given_initFailure_when_loadCompletes_then_staysLoading() = runTest {
+    fun given_initFailure_when_loadCompletes_then_showsUnavailable() = runTest {
         // GIVEN
         every { networkStateProvider.isOnline() } returns true
         val inviteRepository = FakeInviteRepository().apply {
@@ -189,7 +189,7 @@ class InvitePeopleViewModelTest {
         advanceUntilIdle()
 
         // THEN
-        assertEquals(InvitePeopleState.Loading, viewModel.state.value)
+        assertEquals(InvitePeopleState.Unavailable, viewModel.state.value)
     }
 
     private fun createViewModel(
@@ -245,6 +245,16 @@ class InvitePeopleViewModelTest {
                 expiresAt = "2026-12-31T00:00:00Z",
             )
         )
+
+        override suspend fun getInviteForJoin(token: String): InviteInfoDto =
+            InviteInfoDto(
+                tripId = "trip",
+                title = "Trip",
+                startDate = "2026-01-10",
+                endDate = "2026-01-12",
+                locationLine = null,
+                expiresAt = "2026-12-31T00:00:00Z",
+            )
 
         override suspend fun acceptInvite(token: String): String = "trip"
 

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripScreenComposeTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripScreenComposeTest.kt
@@ -122,6 +122,16 @@ class JoinTripScreenComposeTest {
                     )
                 )
 
+                override suspend fun getInviteForJoin(token: String): InviteInfoDto =
+                    InviteInfoDto(
+                        tripId = "trip",
+                        title = "Trip",
+                        startDate = "2026-01-10",
+                        endDate = "2026-01-12",
+                        locationLine = null,
+                        expiresAt = "2026-12-31T00:00:00Z",
+                    )
+
                 override suspend fun acceptInvite(token: String): String = "trip"
 
                 override suspend fun joinTripById(tripId: String): String = tripId

--- a/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripViewModelTest.kt
+++ b/android/app/src/test/java/nvk/cotrip/ui/invitation/JoinTripViewModelTest.kt
@@ -324,6 +324,13 @@ class JoinTripViewModelTest {
             emit(inviteByToken[token] ?: inviteInfo(tripId = "trip-from-$token"))
         }
 
+        override suspend fun getInviteForJoin(token: String): InviteInfoDto? {
+            return runCatching {
+                if (getInviteError != null) return null
+                inviteByToken[token] ?: inviteInfo(tripId = "trip-from-$token")
+            }.getOrNull()
+        }
+
         override suspend fun acceptInvite(token: String): String {
             acceptCalls += token
             return acceptResult

--- a/backend/src/main/kotlin/nvk/cotrip/backend/comments/SystemCommentMetadata.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/comments/SystemCommentMetadata.kt
@@ -1,0 +1,30 @@
+package nvk.cotrip.backend.comments
+
+data class SystemCommentMetadata(
+    val systemKey: String?,
+    val systemActorName: String?,
+)
+
+object SystemCommentMetadataResolver {
+    private val editedIdea = Regex("^(.*) edited the idea$")
+    private val addedToItinerary = Regex("^(.*) added this idea to the itinerary$")
+
+    fun resolve(type: String, body: String): SystemCommentMetadata {
+        if (!type.equals("system", ignoreCase = true)) {
+            return SystemCommentMetadata(systemKey = null, systemActorName = null)
+        }
+        editedIdea.matchEntire(body.trim())?.groupValues?.getOrNull(1)?.let { actor ->
+            return SystemCommentMetadata(
+                systemKey = "idea_edited",
+                systemActorName = actor.trim().takeIf { it.isNotEmpty() },
+            )
+        }
+        addedToItinerary.matchEntire(body.trim())?.groupValues?.getOrNull(1)?.let { actor ->
+            return SystemCommentMetadata(
+                systemKey = "idea_added_to_itinerary",
+                systemActorName = actor.trim().takeIf { it.isNotEmpty() },
+            )
+        }
+        return SystemCommentMetadata(systemKey = null, systemActorName = null)
+    }
+}

--- a/backend/src/main/kotlin/nvk/cotrip/backend/db/CommentRepository.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/db/CommentRepository.kt
@@ -22,6 +22,28 @@ data class CommentPage(
 )
 
 object CommentRepository {
+    fun ideaIdsWithUserCommentHistory(ideaIds: List<String>): Set<String> = dbQuery { conn ->
+        if (ideaIds.isEmpty()) return@dbQuery emptySet()
+        val placeholders = ideaIds.joinToString(",") { "?" }
+        val sql = """
+            SELECT DISTINCT idea_id::text AS idea_id
+            FROM idea_comments
+            WHERE idea_id IN ($placeholders) AND type = 'user'
+        """.trimIndent()
+        conn.prepareStatement(sql).use { stmt ->
+            ideaIds.forEachIndexed { idx, id ->
+                stmt.setObject(idx + 1, UUID.fromString(id))
+            }
+            stmt.executeQuery().use { rs ->
+                val result = mutableSetOf<String>()
+                while (rs.next()) {
+                    result += rs.getString("idea_id")
+                }
+                result
+            }
+        }
+    }
+
     fun countByIdeaIds(ideaIds: List<String>): Map<String, Int> = dbQuery { conn ->
         if (ideaIds.isEmpty()) return@dbQuery emptyMap<String, Int>()
         val placeholders = ideaIds.joinToString(",") { "?" }

--- a/backend/src/main/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClient.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClient.kt
@@ -71,6 +71,25 @@ object OpenWeatherClient {
             .distinctBy { candidate -> candidate.providerId }
     }
 
+    suspend fun reverseLocalCityLabel(
+        apiKey: String,
+        lat: Double,
+        lon: Double,
+        preferredLang: String,
+    ): String? {
+        val lang = preferredLang.lowercase().take(2).ifBlank { return null }
+        val response = httpClient.get("https://api.openweathermap.org/geo/1.0/reverse") {
+            parameter("lat", lat)
+            parameter("lon", lon)
+            parameter("limit", 1)
+            parameter("appid", apiKey)
+        }.body<List<ReverseGeocodingDto>>()
+        val item = response.firstOrNull() ?: return null
+        val fromLocal = item.localNames?.get(lang)
+            ?: item.localNames?.entries?.firstOrNull()?.value
+        return (fromLocal ?: item.name).trim().takeIf { it.isNotEmpty() }
+    }
+
     suspend fun fetchDailyForecast(
         apiKey: String,
         lat: Double,
@@ -106,6 +125,12 @@ private data class DirectGeocodingDto(
     val lon: Double,
     val country: String? = null,
     val state: String? = null,
+)
+
+@Serializable
+private data class ReverseGeocodingDto(
+    val name: String,
+    @SerialName("local_names") val localNames: Map<String, String>? = null,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/CommentRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/CommentRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import kotlinx.serialization.Serializable
+import nvk.cotrip.backend.comments.SystemCommentMetadataResolver
 import nvk.cotrip.backend.db.CommentRepository
 import nvk.cotrip.backend.db.IdeaRepository
 import nvk.cotrip.backend.db.TripRepository
@@ -68,6 +69,7 @@ fun Route.commentRoutes() {
                 .associateWith { authorId -> UserRepository.findById(authorId)?.name }
 
             val comments = commentRows.map {
+                val meta = SystemCommentMetadataResolver.resolve(it.type, it.body)
                 CommentDto(
                     id = it.id,
                     ideaId = it.ideaId,
@@ -76,6 +78,8 @@ fun Route.commentRoutes() {
                     type = it.type,
                     body = it.body,
                     createdAt = it.createdAt.toString(),
+                    systemKey = meta.systemKey,
+                    systemActorName = meta.systemActorName,
                 )
             }
 

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/IdeaRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/IdeaRoutes.kt
@@ -85,8 +85,12 @@ fun Route.ideaRoutes() {
             if (limit == null && cursor.isNullOrBlank()) {
                 val ideas = IdeaRepository.list(tripId, search, status, authorId, city)
                 val commentCounts = CommentRepository.countByIdeaIds(ideas.map { it.id })
+                val historyIds = CommentRepository.ideaIdsWithUserCommentHistory(ideas.map { it.id })
                 val items = ideas.map { idea ->
-                    idea.toDto(commentCounts[idea.id] ?: 0)
+                    idea.toDto(
+                        commentsCount = commentCounts[idea.id] ?: 0,
+                        hasHumanCommentHistory = historyIds.contains(idea.id),
+                    )
                 }
                 call.respond(IdeaListResponse(items = items, nextCursor = null))
             } else {
@@ -100,8 +104,12 @@ fun Route.ideaRoutes() {
                     cursor = cursor,
                 )
                 val commentCounts = CommentRepository.countByIdeaIds(page.items.map { it.id })
+                val historyIds = CommentRepository.ideaIdsWithUserCommentHistory(page.items.map { it.id })
                 val items = page.items.map { idea ->
-                    idea.toDto(commentCounts[idea.id] ?: 0)
+                    idea.toDto(
+                        commentsCount = commentCounts[idea.id] ?: 0,
+                        hasHumanCommentHistory = historyIds.contains(idea.id),
+                    )
                 }
                 call.respond(
                     IdeaListResponse(
@@ -150,7 +158,7 @@ fun Route.ideaRoutes() {
                 ideaTitle = idea.title
             )
 
-            call.respond(idea.toDto(0))
+            call.respond(idea.toDto(commentsCount = 0, hasHumanCommentHistory = false))
         }
 
         get("/v1/ideas/{ideaId}") {
@@ -177,7 +185,9 @@ fun Route.ideaRoutes() {
             }
 
             val commentCount = CommentRepository.countByIdeaIds(listOf(idea.id))[idea.id] ?: 0
-            call.respond(idea.toDto(commentCount))
+            val hasHumanCommentHistory =
+                CommentRepository.ideaIdsWithUserCommentHistory(listOf(idea.id)).contains(idea.id)
+            call.respond(idea.toDto(commentCount, hasHumanCommentHistory = hasHumanCommentHistory))
         }
 
         patch("/v1/ideas/{ideaId}") {
@@ -238,7 +248,9 @@ fun Route.ideaRoutes() {
             }
 
             val commentCount = CommentRepository.countByIdeaIds(listOf(updated.id))[updated.id] ?: 0
-            call.respond(updated.toDto(commentCount))
+            val hasHumanCommentHistory =
+                CommentRepository.ideaIdsWithUserCommentHistory(listOf(updated.id)).contains(updated.id)
+            call.respond(updated.toDto(commentCount, hasHumanCommentHistory = hasHumanCommentHistory))
         }
 
         delete("/v1/ideas/{ideaId}") {
@@ -304,7 +316,9 @@ fun Route.ideaRoutes() {
             }
 
             val commentCount = CommentRepository.countByIdeaIds(listOf(updated.id))[updated.id] ?: 0
-            call.respond(updated.toDto(commentCount))
+            val hasHumanCommentHistory =
+                CommentRepository.ideaIdsWithUserCommentHistory(listOf(updated.id)).contains(updated.id)
+            call.respond(updated.toDto(commentCount, hasHumanCommentHistory = hasHumanCommentHistory))
         }
 
         post("/v1/ideas/{ideaId}/reject") {
@@ -337,7 +351,9 @@ fun Route.ideaRoutes() {
             }
 
             val commentCount = CommentRepository.countByIdeaIds(listOf(updated.id))[updated.id] ?: 0
-            call.respond(updated.toDto(commentCount))
+            val hasHumanCommentHistory =
+                CommentRepository.ideaIdsWithUserCommentHistory(listOf(updated.id)).contains(updated.id)
+            call.respond(updated.toDto(commentCount, hasHumanCommentHistory = hasHumanCommentHistory))
         }
 
         post("/v1/ideas/{ideaId}/convert-to-activity") {
@@ -413,7 +429,10 @@ private fun ideaChanged(before: IdeaRow, after: IdeaRow): Boolean {
         before.status != after.status
 }
 
-private fun IdeaRow.toDto(commentsCount: Int = 0): IdeaDto = IdeaDto(
+private fun IdeaRow.toDto(
+    commentsCount: Int = 0,
+    hasHumanCommentHistory: Boolean? = null,
+): IdeaDto = IdeaDto(
     id = id,
     tripId = tripId,
     authorId = authorId,
@@ -426,4 +445,5 @@ private fun IdeaRow.toDto(commentsCount: Int = 0): IdeaDto = IdeaDto(
     status = status,
     updatedAt = updatedAt.toString(),
     commentsCount = commentsCount,
+    hasHumanCommentHistory = hasHumanCommentHistory,
 )

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/Models.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/Models.kt
@@ -58,6 +58,8 @@ data class CommentDto(
     val type: String,
     val body: String,
     val createdAt: String,
+    val systemKey: String? = null,
+    val systemActorName: String? = null,
 )
 
 @Serializable
@@ -84,6 +86,7 @@ data class IdeaDto(
     val status: String,
     val updatedAt: String,
     val commentsCount: Int = 0,
+    val hasHumanCommentHistory: Boolean? = null,
 )
 
 @Serializable
@@ -178,6 +181,7 @@ data class WeatherForecastResponseDto(
     val availableTo: String? = null,
     val missingDates: List<String> = emptyList(),
     val nextRefreshAt: String? = null,
+    val displayCity: String? = null,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/WeatherRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/WeatherRoutes.kt
@@ -66,6 +66,8 @@ fun Route.weatherRoutes(weatherConfig: WeatherConfig) {
                     end = end,
                     cacheUsed = true,
                     refreshTtlHours = weatherConfig.refreshTtlHours,
+                    acceptLanguage = call.request.headers["Accept-Language"],
+                    weatherConfig = weatherConfig,
                 )
             )
         }
@@ -182,6 +184,8 @@ fun Route.weatherRoutes(weatherConfig: WeatherConfig) {
                     end = end,
                     cacheUsed = cacheUsed,
                     refreshTtlHours = weatherConfig.refreshTtlHours,
+                    acceptLanguage = call.request.headers["Accept-Language"],
+                    weatherConfig = weatherConfig,
                 )
             )
         }
@@ -216,13 +220,15 @@ private fun resolveProviderWindow(start: LocalDate, end: LocalDate): Pair<LocalD
     return if (from.isAfter(to)) null else from to to
 }
 
-private fun buildWeatherResponse(
+private suspend fun buildWeatherResponse(
     tripId: String,
     city: String,
     start: LocalDate,
     end: LocalDate,
     cacheUsed: Boolean,
     refreshTtlHours: Int,
+    acceptLanguage: String?,
+    weatherConfig: WeatherConfig,
 ): WeatherForecastResponseDto {
     val rows = WeatherRepository.list(tripId, city, start, end)
     val items = rows.map { it.toDto() }
@@ -235,6 +241,13 @@ private fun buildWeatherResponse(
         ?.plusHours(refreshTtlHours.toLong())
         ?.toString()
 
+    val displayCity = enrichDisplayCity(
+        acceptLanguage = acceptLanguage,
+        tripId = tripId,
+        city = city,
+        weatherConfig = weatherConfig,
+    )
+
     return WeatherForecastResponseDto(
         items = items,
         nextCursor = null,
@@ -243,7 +256,28 @@ private fun buildWeatherResponse(
         availableTo = providerWindow?.second?.toString(),
         missingDates = missingDates,
         nextRefreshAt = nextRefreshAt,
+        displayCity = displayCity,
     )
+}
+
+private suspend fun enrichDisplayCity(
+    acceptLanguage: String?,
+    tripId: String,
+    city: String,
+    weatherConfig: WeatherConfig,
+): String? {
+    val header = acceptLanguage?.trim()?.lowercase() ?: return null
+    if (!header.startsWith("ru")) return null
+    val apiKey = weatherConfig.openWeatherApiKey ?: return null
+    val coordinates = ItineraryDayRepository.findCityCoordinates(tripId = tripId, city = city) ?: return null
+    return runCatching {
+        OpenWeatherClient.reverseLocalCityLabel(
+            apiKey = apiKey,
+            lat = coordinates.cityLat,
+            lon = coordinates.cityLon,
+            preferredLang = "ru",
+        )
+    }.getOrNull()
 }
 
 private fun datesBetween(start: LocalDate, end: LocalDate): List<LocalDate> {

--- a/backend/src/main/kotlin/nvk/cotrip/backend/ws/CommentEventsPublisher.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/ws/CommentEventsPublisher.kt
@@ -3,6 +3,7 @@ package nvk.cotrip.backend.ws
 import io.ktor.websocket.Frame
 import io.ktor.websocket.send
 import kotlinx.serialization.encodeToString
+import nvk.cotrip.backend.comments.SystemCommentMetadataResolver
 import nvk.cotrip.backend.db.CommentRow
 
 suspend fun publishCommentCreated(
@@ -11,6 +12,7 @@ suspend fun publishCommentCreated(
     authorName: String? = null,
     clientMessageId: String? = null,
 ) {
+    val meta = SystemCommentMetadataResolver.resolve(comment.type, comment.body)
     val payload = CommentCreatedMessage(
         payload = CommentCreatedPayload(
             id = comment.id,
@@ -21,6 +23,8 @@ suspend fun publishCommentCreated(
             body = comment.body,
             createdAt = comment.createdAt.toString(),
             clientMessageId = clientMessageId,
+            systemKey = meta.systemKey,
+            systemActorName = meta.systemActorName,
         )
     )
     val text = WsJson.instance.encodeToString(payload)

--- a/backend/src/main/kotlin/nvk/cotrip/backend/ws/CommentsMessages.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/ws/CommentsMessages.kt
@@ -54,6 +54,8 @@ data class CommentCreatedPayload(
     val body: String,
     val createdAt: String,
     val clientMessageId: String? = null,
+    val systemKey: String? = null,
+    val systemActorName: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary
Full-stack change (Android + backend) for the UI and offline fix plan: block optimistic offline create/join/share for new operations, improve read paths from cache, and add backward-compatible API fields.

## Android
- Send `Accept-Language` on API requests.
- Remove repository-level offline enqueue for new creates (trip, idea, expense, activity, AI save, convert); fail fast with network errors.
- Trip forecast and expenses: build state from cached trip/itinerary/weather/members; forecast shows `displayCity` when present; client-side weather description localization.
- AI route input vs generated ideas: disclaimer placement, adaptive chip layout, multiline toasts (`CoTripToast`).
- Idea discussion tab visibility; localized system comments (metadata + legacy English parsing).
- Invite/join: unavailable/retry and preflight fixes; Activity details silent auto-refresh.
- User pull-to-refresh on forecast surfaces weather refresh failures (toast) while silent refresh keeps cached data.

## Backend (compatible)
- Optional `displayCity` on weather responses; RU enrichment when `Accept-Language` starts with `ru`.
- Optional `hasHumanCommentHistory` on ideas; optional `systemKey` / `systemActorName` on comments (REST + WS).

## Tests
- `./gradlew :app:testDebugUnitTest` and `backend/./gradlew test` pass locally.