### PR TITLE
Localize city names via OpenWeather local_names (en/ru)

### DIFF
--- a/backend/src/main/kotlin/nvk/cotrip/backend/http/AcceptLanguage.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/http/AcceptLanguage.kt
@@ -1,9 +1,5 @@
 package nvk.cotrip.backend.http
 
-/**
- * Maps the first [Accept-Language] tag to a two-letter code used with OpenWeather `local_names`.
- * Only [en] and [ru] are handled for UI; other locales fall back to API default `name` fields.
- */
 fun preferredOpenWeatherUiLang(acceptLanguage: String?): String? {
     val header = acceptLanguage?.trim()?.lowercase() ?: return null
     if (header.isEmpty()) return null

--- a/backend/src/main/kotlin/nvk/cotrip/backend/http/AcceptLanguage.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/http/AcceptLanguage.kt
@@ -1,0 +1,17 @@
+package nvk.cotrip.backend.http
+
+/**
+ * Maps the first [Accept-Language] tag to a two-letter code used with OpenWeather `local_names`.
+ * Only [en] and [ru] are handled for UI; other locales fall back to API default `name` fields.
+ */
+fun preferredOpenWeatherUiLang(acceptLanguage: String?): String? {
+    val header = acceptLanguage?.trim()?.lowercase() ?: return null
+    if (header.isEmpty()) return null
+    val firstPart = header.split(',').firstOrNull()?.trim() ?: return null
+    val tag = firstPart.substringBefore(';').trim().ifEmpty { return null }
+    val primary = tag.substringBefore('-').take(2).lowercase()
+    return when (primary) {
+        "en", "ru" -> primary
+        else -> null
+    }
+}

--- a/backend/src/main/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClient.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClient.kt
@@ -43,6 +43,7 @@ object OpenWeatherClient {
         apiKey: String,
         query: String,
         limit: Int,
+        preferredLang: String? = null,
     ): List<OpenWeatherCityCandidate> {
         val response = httpClient.get("https://api.openweathermap.org/geo/1.0/direct") {
             parameter("q", query)
@@ -52,7 +53,7 @@ object OpenWeatherClient {
 
         return response
             .mapNotNull { item ->
-                val cityName = item.name.trim()
+                val cityName = localizedDirectCityName(item, preferredLang)
                 if (cityName.isBlank()) return@mapNotNull null
                 val parts = listOfNotNull(
                     cityName.takeIf { it.isNotBlank() },
@@ -69,6 +70,12 @@ object OpenWeatherClient {
                 )
             }
             .distinctBy { candidate -> candidate.providerId }
+    }
+
+    private fun localizedDirectCityName(item: DirectGeocodingDto, preferredLang: String?): String {
+        val lang = preferredLang?.lowercase()?.take(2)?.takeIf { it.isNotBlank() }
+        val fromLocal = lang?.let { l -> item.localNames?.get(l) }
+        return (fromLocal ?: item.name).trim()
     }
 
     suspend fun reverseLocalCityLabel(
@@ -125,6 +132,7 @@ private data class DirectGeocodingDto(
     val lon: Double,
     val country: String? = null,
     val state: String? = null,
+    @SerialName("local_names") val localNames: Map<String, String>? = null,
 )
 
 @Serializable

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/ItineraryRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/ItineraryRoutes.kt
@@ -20,6 +20,7 @@ import nvk.cotrip.backend.db.DayRepository
 import nvk.cotrip.backend.db.ItineraryDayRepository
 import nvk.cotrip.backend.db.LocalPlacesSearchRepository
 import nvk.cotrip.backend.db.TripRepository
+import nvk.cotrip.backend.http.preferredOpenWeatherUiLang
 import nvk.cotrip.backend.integrations.OpenWeatherClient
 
 @Serializable
@@ -111,11 +112,13 @@ fun Route.itineraryRoutes(weatherConfig: WeatherConfig) {
             }
 
             val limit = call.request.queryParameters["limit"]?.toIntOrNull()?.coerceIn(1, 20) ?: 8
+            val uiLang = preferredOpenWeatherUiLang(call.request.headers["Accept-Language"])
             val suggestions = runCatching {
                 OpenWeatherClient.searchCities(
                     apiKey = apiKey,
                     query = query,
                     limit = limit,
+                    preferredLang = uiLang,
                 )
             }.getOrElse {
                 call.respond(

--- a/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/WeatherRoutes.kt
+++ b/backend/src/main/kotlin/nvk/cotrip/backend/routes/v1/WeatherRoutes.kt
@@ -15,6 +15,7 @@ import nvk.cotrip.backend.config.WeatherConfig
 import nvk.cotrip.backend.db.ItineraryDayRepository
 import nvk.cotrip.backend.db.TripRepository
 import nvk.cotrip.backend.db.WeatherRepository
+import nvk.cotrip.backend.http.preferredOpenWeatherUiLang
 import nvk.cotrip.backend.integrations.OpenWeatherClient
 
 fun Route.weatherRoutes(weatherConfig: WeatherConfig) {
@@ -266,8 +267,7 @@ private suspend fun enrichDisplayCity(
     city: String,
     weatherConfig: WeatherConfig,
 ): String? {
-    val header = acceptLanguage?.trim()?.lowercase() ?: return null
-    if (!header.startsWith("ru")) return null
+    val uiLang = preferredOpenWeatherUiLang(acceptLanguage) ?: return null
     val apiKey = weatherConfig.openWeatherApiKey ?: return null
     val coordinates = ItineraryDayRepository.findCityCoordinates(tripId = tripId, city = city) ?: return null
     return runCatching {
@@ -275,7 +275,7 @@ private suspend fun enrichDisplayCity(
             apiKey = apiKey,
             lat = coordinates.cityLat,
             lon = coordinates.cityLon,
-            preferredLang = "ru",
+            preferredLang = uiLang,
         )
     }.getOrNull()
 }

--- a/backend/src/test/kotlin/nvk/cotrip/backend/http/AcceptLanguageTest.kt
+++ b/backend/src/test/kotlin/nvk/cotrip/backend/http/AcceptLanguageTest.kt
@@ -1,0 +1,18 @@
+package nvk.cotrip.backend.http
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AcceptLanguageTest {
+
+    @Test
+    fun preferredOpenWeatherUiLang_parses_en_and_ru() {
+        assertEquals("en", preferredOpenWeatherUiLang("en-US"))
+        assertEquals("en", preferredOpenWeatherUiLang("en-GB, ru;q=0.8"))
+        assertEquals("ru", preferredOpenWeatherUiLang("ru-RU"))
+        assertNull(preferredOpenWeatherUiLang("de-DE"))
+        assertNull(preferredOpenWeatherUiLang(null))
+        assertNull(preferredOpenWeatherUiLang(""))
+    }
+}

--- a/backend/src/test/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClientTest.kt
+++ b/backend/src/test/kotlin/nvk/cotrip/backend/integrations/OpenWeatherClientTest.kt
@@ -61,6 +61,24 @@ class OpenWeatherClientTest {
     }
 
     @Test
+    fun given_localNames_when_searchCitiesWithPreferredLang_then_usesLocalizedName() = runBlocking {
+        val json =
+            """[{"name":"Moscow","local_names":{"en":"Moscow","ru":"Москва"},"lat":55.75,"lon":37.62,"country":"RU","state":null}]"""
+        val mockEngine = MockEngine { respond(json, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json")) }
+        OpenWeatherClient.httpClientForTest = io.ktor.client.HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val ru = OpenWeatherClient.searchCities(apiKey = "key", query = "Moscow", limit = 5, preferredLang = "ru")
+        val en = OpenWeatherClient.searchCities(apiKey = "key", query = "Moscow", limit = 5, preferredLang = "en")
+
+        assertEquals("Москва", ru.first().name)
+        assertEquals("Moscow", en.first().name)
+    }
+
+    @Test
     fun given_limitOutOfRange_when_searchCities_then_coercesToValidRange() = runBlocking {
         // GIVEN — client coerces limit to 1..20; we just verify no throw
         val mockEngine = MockEngine { respond("[]", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json")) }


### PR DESCRIPTION
Backend-only: use `Accept-Language` (already sent by the Android app) to pick `en` or `ru` for OpenWeather Geo API `local_names` on city search and weather `displayCity`. Falls back to API `name` when the locale key is missing or the UI language is not en/ru.