### PR TITLE
Itinerary: batch city apply, dedupe picker, Cursor settings

### DIFF
--- a/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/aisuggestions/BuildRouteViewModel.kt
@@ -13,8 +13,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import nvk.cotrip.R
+import nvk.cotrip.data.network.dto.cityDisplayLabel
 import nvk.cotrip.data.repository.ItineraryRepository
 import nvk.cotrip.ui.common.TextInputLimits
+import nvk.cotrip.ui.common.appUiLocale
 import nvk.cotrip.ui.navigation.AppNavigator
 import nvk.cotrip.ui.navigation.Destination
 import javax.inject.Inject
@@ -139,8 +141,9 @@ class BuildRouteViewModel @Inject constructor(
         viewModelScope.launch {
             val cities = runCatching {
                 itineraryRepository.getItinerary(tripId).first()
-                    .mapNotNull { it.city?.trim()?.takeIf { city -> city.isNotBlank() } }
-                    .distinct()
+                    .map { it.cityDisplayLabel() }
+                    .filter { it.isNotBlank() }
+                    .distinctBy { it.lowercase(appUiLocale()) }
             }.getOrNull().orEmpty()
 
             if (cities.isNotEmpty()) {

--- a/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/forecast/TripForecastViewModel.kt
@@ -18,6 +18,7 @@ import nvk.cotrip.data.network.dto.ItineraryDayDto
 import nvk.cotrip.data.network.dto.WeatherForecastResponseDto
 import nvk.cotrip.data.network.dto.cityDisplayLabel
 import nvk.cotrip.data.repository.ItineraryRepository
+import nvk.cotrip.ui.common.appUiLocale
 import nvk.cotrip.data.repository.TripRepository
 import nvk.cotrip.data.repository.WeatherRepository
 import nvk.cotrip.ui.common.UiErrorMapper
@@ -286,14 +287,16 @@ class TripForecastViewModel @Inject constructor(
     }
 
     private fun collectCityOptions(days: List<ItineraryDayDto>): List<WeatherCityOption> {
-        val seen = linkedSetOf<String>()
+        val seenDisplayKeys = linkedSetOf<String>()
         val result = mutableListOf<WeatherCityOption>()
         days.sortedBy { it.dayNumber }.forEach { day ->
             val key = day.city?.trim()?.takeIf { it.isNotEmpty() } ?: return@forEach
             if (day.cityLat == null || day.cityLon == null) return@forEach
-            if (key in seen) return@forEach
-            seen.add(key)
-            result += WeatherCityOption(key = key, label = day.cityDisplayLabel())
+            val label = day.cityDisplayLabel()
+            val displayKey = label.trim().lowercase(appUiLocale())
+            if (displayKey in seenDisplayKeys) return@forEach
+            seenDisplayKeys.add(displayKey)
+            result += WeatherCityOption(key = key, label = label)
         }
         return result
     }

--- a/android/app/src/main/java/nvk/cotrip/ui/itinerary/CityPickerState.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/itinerary/CityPickerState.kt
@@ -1,5 +1,7 @@
 package nvk.cotrip.ui.itinerary
 
+import nvk.cotrip.ui.common.appUiLocale
+
 data class CitySuggestionUi(
     val name: String,
     val providerId: String? = null,
@@ -17,3 +19,8 @@ data class CityPickerState(
     val suggestions: List<CitySuggestionUi>,
     val isSearching: Boolean,
 )
+
+internal fun CitySuggestionUi.visibleCityPickerDedupeKey(): String {
+    val visible = fullText?.trim()?.takeIf { it.isNotEmpty() } ?: name.trim()
+    return visible.lowercase(appUiLocale())
+}

--- a/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryViewModel.kt
+++ b/android/app/src/main/java/nvk/cotrip/ui/itinerary/TripItineraryViewModel.kt
@@ -334,6 +334,7 @@ class TripItineraryViewModel @Inject constructor(
                                 fullText = it.fullText,
                             )
                         }
+                        .distinctBy { it.visibleCityPickerDedupeKey() }
                     _state.update { st ->
                         val current = st.cityPicker ?: return@update st
                         if (current.query != query) {
@@ -356,7 +357,7 @@ class TripItineraryViewModel @Inject constructor(
                         }
                         val fallback = current.localSuggestions.filter {
                             it.name.contains(query, ignoreCase = true)
-                        }
+                        }.distinctBy { it.visibleCityPickerDedupeKey() }
                         st.copy(
                             cityPicker = current.copy(
                                 suggestions = fallback,
@@ -616,17 +617,12 @@ private fun collectTripCities(days: List<ItineraryDayDto>): List<CitySuggestionU
             current
         }
     }
-    return byName.values.toList().distinctBy { it.tripCityDedupeKey() }
+    return byName.values.toList().distinctBy { it.visibleCityPickerDedupeKey() }
 }
 
 private fun CitySuggestionDto.citySearchDedupeKey(): String {
     val trimmedProvider = providerId?.trim()?.takeIf { it.isNotEmpty() }
     return trimmedProvider ?: "$lat:$lon:${name.trim()}"
-}
-
-private fun CitySuggestionUi.tripCityDedupeKey(): String {
-    val trimmedProvider = providerId?.trim()?.takeIf { it.isNotEmpty() }
-    return trimmedProvider ?: "$lat:$lon:${name.trim().lowercase(appUiLocale())}"
 }
 
 private fun ItineraryDayDto.toUi(currencySymbol: String): ItineraryDayUi {


### PR DESCRIPTION
This PR includes:

- **Batch apply city to following days**: single local cache update after updating all targeted days to avoid staggered UI updates; clear `cityDisplayName` on local day updates so labels match `cityDisplayLabel()` truncation; optimistic single-day label uses comma truncation.

- **City picker deduplication**: remove duplicate rows that look identical in bottom sheets (itinerary search/local list, forecast city options, build-route city list) by deduping on the visible label.

- **Cursor workspace settings** (`.cursor/settings.json`) from an earlier commit on this branch.

Please review especially offline/partial HTTP behavior for `updateDaysCity` and weather/API keys when duplicate raw `city` strings collapse to one display label.